### PR TITLE
PRO-1123: Remove hidden text from links on Check Your Answers

### DIFF
--- a/app/views/widgets/checkanswer.html
+++ b/app/views/widgets/checkanswer.html
@@ -26,7 +26,7 @@
     <td class="change-answer">
         {% if alreadyDeclared === 'false' %}
             {% set actionLink = common.change if complete else common.answer %}
-            <a href="{{url}}">{{actionLink}}<span class="visuallyhidden">{{actionLink}}</span></a>
+            <a href="{{url}}">{{actionLink}}</a>
         {% endif %}
     </td>
 </tr>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PRO-1123

### Change description ###
After much discussion and researching, the desired solution is now to
remove the hidden text from our links on Check Your Answers page, as per
the approved Divorce solution.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
