### PR TITLE
PRO-2530: Check Your Answer page displays deceased Alias name when the user has changed the previous question's answer to "No"

### DIFF
--- a/app/steps/ui/deceased/alias/index.js
+++ b/app/steps/ui/deceased/alias/index.js
@@ -1,6 +1,7 @@
 const ValidationStep = require('app/core/steps/ValidationStep');
 const {get} = require('lodash');
 const WillWrapper = require('app/wrappers/Will');
+const DeceasedWrapper = require('app/wrappers/Deceased');
 
 module.exports = class DeceasedAlias extends ValidationStep {
 
@@ -27,6 +28,14 @@ module.exports = class DeceasedAlias extends ValidationStep {
         const codicils = willWrapper.hasCodicils();
         ctx.deceasedMarriedAfterDateOnCodicilOrWill = isCodicilDated || (!codicils && isWillDated);
         return ctx;
+    }
+
+    handlePost(ctx, errors) {
+        const hasAlias = (new DeceasedWrapper(ctx.deceased)).hasAlias();
+        if (!hasAlias) {
+            delete ctx.otherNames;
+        }
+        return [ctx, errors];
     }
 
     action(ctx, formdata) {

--- a/app/steps/ui/deceased/alias/index.js
+++ b/app/steps/ui/deceased/alias/index.js
@@ -1,5 +1,4 @@
 const ValidationStep = require('app/core/steps/ValidationStep');
-const {get} = require('lodash');
 const WillWrapper = require('app/wrappers/Will');
 const DeceasedWrapper = require('app/wrappers/Deceased');
 
@@ -44,9 +43,8 @@ module.exports = class DeceasedAlias extends ValidationStep {
         return [ctx, formdata];
     }
 
-    isSoftStop(formdata, ctx) {
-        const assetsInAnotherName = get(formdata, 'deceased.alias', {});
-        const softStopForAssetsInAnotherName = assetsInAnotherName === this.generateContent(ctx, formdata).optionYes;
+    isSoftStop(formdata) {
+        const softStopForAssetsInAnotherName = (new DeceasedWrapper(formdata.deceased)).hasAlias();
         return {
             'stepName': this.constructor.name,
             'isSoftStop': softStopForAssetsInAnotherName

--- a/app/steps/ui/deceased/married/index.js
+++ b/app/steps/ui/deceased/married/index.js
@@ -1,6 +1,6 @@
 const ValidationStep = require('app/core/steps/ValidationStep');
-const {get} = require('lodash');
 const WillWrapper = require('app/wrappers/Will');
+const DeceasedWrapper = require('app/wrappers/Deceased');
 
 module.exports = class DeceasedMarried extends ValidationStep {
 
@@ -8,17 +8,15 @@ module.exports = class DeceasedMarried extends ValidationStep {
         return '/deceased-married';
     }
 
-    isSoftStop(formdata, ctx) {
-        const marriedAfterWill = get(formdata, 'deceased.married', {});
-        const softStopForMarriedAfterWill = marriedAfterWill === this.generateContent(ctx, formdata).optionYes;
-
+    isSoftStop(formdata) {
+        const softStopForMarriedAfterWill = (new DeceasedWrapper(formdata.deceased)).isMarried();
         return {
             'stepName': this.constructor.name,
             'isSoftStop': softStopForMarriedAfterWill
         };
     }
 
-    * handleGet(ctx, formdata) {
+    handleGet(ctx, formdata) {
         ctx.codicilPresent = (new WillWrapper(formdata.will)).hasCodicilsDate();
         return [ctx];
     }

--- a/app/wrappers/Deceased.js
+++ b/app/wrappers/Deceased.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const commonContent = require('app/resources/en/translation/common');
+
+class Deceased {
+    constructor(deceased) {
+        this.deceased = deceased || {};
+    }
+
+    hasAlias() {
+        return this.deceased.alias === commonContent.yes;
+    }
+
+    isMarried() {
+        return this.deceased.married === commonContent.yes;
+    }
+}
+
+module.exports = Deceased;

--- a/test/unit/testDeceasedWrapper.js
+++ b/test/unit/testDeceasedWrapper.js
@@ -1,0 +1,54 @@
+const DeceasedWrapper = require('app/wrappers/Deceased');
+const commonContent = require('app/resources/en/translation/common');
+const chai = require('chai');
+const expect = chai.expect;
+
+describe('Deceased.js', () => {
+    describe('hasAlias()', () => {
+        it('should return true when the deceased has an alias', (done) => {
+            const data = {alias: commonContent.yes};
+            const deceasedWrapper = new DeceasedWrapper(data);
+            expect(deceasedWrapper.hasAlias()).to.equal(true);
+            done();
+        });
+
+        describe('should return false', () => {
+            it('when the deceased does not have an alias', (done) => {
+                const data = {alias: commonContent.no};
+                const deceasedWrapper = new DeceasedWrapper(data);
+                expect(deceasedWrapper.hasAlias()).to.equal(false);
+                done();
+            });
+
+            it('when there is no deceased data', (done) => {
+                const deceasedWrapper = new DeceasedWrapper();
+                expect(deceasedWrapper.hasAlias()).to.equal(false);
+                done();
+            });
+        });
+    });
+
+    describe('isMarried()', () => {
+        it('should return true when the deceased is married', (done) => {
+            const data = {married: commonContent.yes};
+            const deceasedWrapper = new DeceasedWrapper(data);
+            expect(deceasedWrapper.isMarried()).to.equal(true);
+            done();
+        });
+
+        describe('should return false', () => {
+            it('when the deceased is not married', (done) => {
+                const data = {married: commonContent.no};
+                const deceasedWrapper = new DeceasedWrapper(data);
+                expect(deceasedWrapper.isMarried()).to.equal(false);
+                done();
+            });
+
+            it('when there is no deceased data', (done) => {
+                const deceasedWrapper = new DeceasedWrapper();
+                expect(deceasedWrapper.isMarried()).to.equal(false);
+                done();
+            });
+        });
+    });
+});


### PR DESCRIPTION
### JIRA link (if applicable) ###

PRO-2530: Release 3.0.0 - Check Your Answer page displays deceased Alias name when the user has changed the previous question's answer to "No" - knock on effect causes Statement of Truth to be incorrect

### Change description ###

- Add declaration wrapper and unit tests
- Unset the deceased other names if the deceased doesn't have an alias
- Refactor the deceased alias and deceased married pages to use the deceased wrapper

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```