### PR TITLE
PRO-2595 - CNP: Add smoke test for probate fronted to get git hash in health end point

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -91,5 +91,6 @@ module.exports = {
     whitelistedPagesAfterPayment: ['/tasklist', '/payment-status', '/documents', '/thankyou'],
     whitelistedPagesAfterDeclaration: ['/tasklist', '/executors-invites-sent', '/copies-uk', '/assets-overseas', '/copies-overseas', '/copies-summary', '/payment-breakdown', '/payment-breakdown?status=failure', '/payment-status', '/documents', '/thankyou'],
     hardStopParams: ['will.left', 'will.original', 'iht.completed', 'applicant.executor'],
-    nonCachedPages: ['summary', 'tasklist']
+    nonCachedPages: ['summary', 'tasklist'],
+    healthEndpoint: '/health'
 };

--- a/app/healthcheck.js
+++ b/app/healthcheck.js
@@ -6,7 +6,11 @@ const {map} = require('lodash');
 const url = require('url');
 const router = require('express').Router();
 const os = require('os');
+const childProcess = require('child_process');
 const gitRevision = process.env.GIT_REVISION;
+const osHostname = os.hostname();
+const gitHash = childProcess.execSync('git rev-parse HEAD');
+const gitHashString = gitHash.toString().trim();
 
 const getServiceHealthUrl = (serviceUrl) => {
     serviceUrl = url.parse(serviceUrl);
@@ -36,11 +40,15 @@ router.get('/', (req, res) => {
             'name': config.service.name,
             'status': 'UP',
             'uptime': process.uptime(),
-            'host': os.hostname(),
+            'host': osHostname,
             'version': gitRevision,
+            'hash': gitHashString,
             downstream
         });
     });
 });
 
 module.exports = router;
+module.exports.getServiceHealthUrl = getServiceHealthUrl;
+module.exports.osHostname = osHostname;
+module.exports.gitHashString = gitHashString;

--- a/app/healthcheck.js
+++ b/app/healthcheck.js
@@ -1,42 +1,36 @@
 'use strict';
 
-/* eslint handle-callback-err: 0 no-unused-vars: 0*/
+const config = require('app/config');
+const {asyncFetch, fetchOptions} = require('app/components/api-utils');
+const {map} = require('lodash');
+const url = require('url');
+const router = require('express').Router();
+const os = require('os');
+const gitRevision = process.env.GIT_REVISION;
 
-const config = require('app/config'),
-      {asyncFetch, fetchOptions} = require('app/components/api-utils'),
-      {map} = require('lodash'),
-      url = require('url'),
-      router = require('express').Router(),
-      os = require('os'),
-      gitRevision = process.env.GIT_REVISION;
+const getServiceHealthUrl = (serviceUrl) => {
+    serviceUrl = url.parse(serviceUrl);
+    const port = serviceUrl.port ? `:${serviceUrl.port}` : '';
+    return `${serviceUrl.protocol}//${serviceUrl.hostname}${port}${config.healthEndpoint}`;
+}
 
 const services = [
-    {'name': 'Validation Service', 'url': getServiceHealthUrl(url.parse(config.services.validation.url))},
-    {'name': 'Submit Service', 'url': getServiceHealthUrl(url.parse(config.services.submit.url))},
-    {'name': 'Persistence Service', 'url': getServiceHealthUrl(url.parse(config.services.persistence.url))}];
+    {'name': 'Validation Service', 'url': getServiceHealthUrl(config.services.validation.url)},
+    {'name': 'Submit Service', 'url': getServiceHealthUrl(config.services.submit.url)},
+    {'name': 'Persistence Service', 'url': getServiceHealthUrl(config.services.persistence.url)}
+];
 
-function createPromisesList(services) {
+const createPromisesList = (services) => {
     const fetchOpts = fetchOptions({}, 'GET', {});
-
-    return map(services,
-        service => asyncFetch(service.url, fetchOpts, res => res.json().then(json => {
-                    return {'name': service.name, 'status': json.status}
-                })
-            ).catch(err => {
-            return {'name': service.name, 'status': 'ERROR'}
-        }));
+    return map(services, service => asyncFetch(service.url, fetchOpts, res => res.json().then(json => {
+        return {'name': service.name, 'status': json.status}
+    })).catch(err => {
+        return {'name': service.name, 'status': err.toString()}
+    }));
 }
 
-function getServiceHealthUrl(url) {
-    const port = url.port ? `:${url.port}` : '';
-    return `${url.protocol}//${url.hostname}${port}/health`;
-}
-
-router.get('/', function (req, res) {
-
-    const healthPromises = [];
-    healthPromises.push(...createPromisesList(services));
-
+router.get('/', (req, res) => {
+    const healthPromises = createPromisesList(services);
     Promise.all(healthPromises).then(downstream => {
         res.json({
             'name': config.service.name,
@@ -47,6 +41,6 @@ router.get('/', function (req, res) {
             downstream
         });
     });
-
 });
+
 module.exports = router;

--- a/test/unit/testHealthcheck.js
+++ b/test/unit/testHealthcheck.js
@@ -1,25 +1,42 @@
 const {expect} = require('chai');
+const server = require('app').init();
+const request = require('supertest');
+const config = require('app/config');
+const healthcheck = require('app/healthcheck');
 
-describe('healthcheck', () => {
+describe('healthcheck.js', () => {
+    describe('getServiceHealthUrl()', () => {
+        describe('should return the correct url', () => {
+            it('when given a service url with a port', (done) => {
+                const serviceUrl = healthcheck.getServiceHealthUrl('http://localhost:8080/validate');
+                expect(serviceUrl).to.equal(`http://localhost:8080${config.healthEndpoint}`);
+                done();
+            });
 
-    it('test should return status up', (done) => {
+            it('when given a service url without a port', (done) => {
+                const serviceUrl = healthcheck.getServiceHealthUrl('http://localhost/validate');
+                expect(serviceUrl).to.equal(`http://localhost${config.healthEndpoint}`);
+                done();
+            });
+        });
+    });
 
-        const server = require('app').init();
-
-        const request = require('supertest');
-        const agent = request.agent(server.app);
-
-        agent.get('/health')
+    describe('/health endpoint', () => {
+        it('should return the correct params', (done) => {
+            const agent = request.agent(server.app);
+            agent.get('/health')
             .expect(200)
             .end((err, res) => {
                 server.http.close();
                 if (err) {
                     throw err;
                 }
-
-                const text = res.text.toLowerCase();
-                expect(text).to.contain('"status":"up"')
+                expect(res.body).to.have.property('name').and.equal(config.service.name);
+                expect(res.body).to.have.property('status').and.equal('UP');
+                expect(res.body).to.have.property('host').and.equal(healthcheck.osHostname);
+                expect(res.body).to.have.property('hash').and.equal(healthcheck.gitHashString);
                 done();
             });
+        });
     });
 });


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/PRO-2595

### Change description ###

- Tidy healthcheck code
- Return git hash from the /health endpoint and export method and variables to use in unit tests
- Tidy unit tests and add unit tests for the getServiceHealthUrl() method

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
