### PR TITLE
PRO-2216 - Multiple registries - Display Relevant registry address on the documents page

### DIFF
--- a/app/resources/en/translation/documents.json
+++ b/app/resources/en/translation/documents.json
@@ -21,7 +21,7 @@
   "warning": "The grant of probate won&rsquo;t be issued if you don&rsquo;t have all the necessary documents and signatures.",
   "heading3": "Send your documents to the probate registry",
   "sendDocuments": "You should send your documents using a signed-for postal service to:",
-  "sendDocumentsAddress": "Digital Application<br>Oxford District Probate Registry<br>Combined Court Building<br>St Aldates<br>Oxford<br>OX1 1LY",
+  "sendDocumentsAddress": "Digital Application\nOxford District Probate Registry\nCombined Court Building\nSt Aldates\nOxford\nOX1 1LY",
   "checkboxLabel": "I understand that I need to sign the will before sending my documents",
   "checkboxLabel-codicils": "I understand that I need to sign the will and any &lsquo;codicils&rsquo; before sending my documents",
   "errors": {

--- a/app/steps/ui/documents/index.js
+++ b/app/steps/ui/documents/index.js
@@ -1,6 +1,7 @@
-const ValidationStep = require('app/core/steps/ValidationStep'),
-    {get} = require('lodash'),
-    ExecutorsWrapper = require('app/wrappers/Executors');
+const ValidationStep = require('app/core/steps/ValidationStep');
+const ExecutorsWrapper = require('app/wrappers/Executors');
+const WillWrapper = require('app/wrappers/Will');
+const DocumentsWrapper = require('app/wrappers/Documents');
 
 module.exports = class Documents extends ValidationStep {
 
@@ -8,11 +9,13 @@ module.exports = class Documents extends ValidationStep {
         return '/documents';
     }
 
-    * handleGet(ctx, formdata) {
-        const executors = get(formdata, 'executors');
-        const executorsWrapper = new ExecutorsWrapper(executors);
+    handleGet(ctx, formdata) {
+        const executorsWrapper = new ExecutorsWrapper(formdata.executors);
+        const registryAddress = (new DocumentsWrapper(formdata.documents)).registryAddress();
+        const content = this.generateContent(ctx, formdata);
 
-        ctx.codicilsNumber = get(formdata, 'will.codicilsNumber');
+        ctx.registryAddress = registryAddress ? registryAddress : content.sendDocumentsAddress;
+        ctx.codicilsNumber = (new WillWrapper(formdata.will)).codicilsNumber();
         ctx.hasMultipleApplicants = executorsWrapper.hasMultipleApplicants();
         ctx.hasRenunciated = executorsWrapper.hasRenunciated();
 

--- a/app/steps/ui/documents/template.html
+++ b/app/steps/ui/documents/template.html
@@ -57,7 +57,7 @@
 
     <p>{{ content.sendDocuments }}</p>
 
-    <p>{{ content.sendDocumentsAddress | safe }}</p>
+    <p>{{ fields.registryAddress.value | safe | nl2br }}</p>
 
     {{ checkbox(
         name='sentDocuments',

--- a/app/wrappers/Documents.js
+++ b/app/wrappers/Documents.js
@@ -1,0 +1,13 @@
+'use strict';
+
+class Documents {
+    constructor(documents) {
+        this.documents = documents || {};
+    }
+
+    registryAddress() {
+        return this.documents.registryAddress ? this.documents.registryAddress : '';
+    }
+}
+
+module.exports = Documents;

--- a/app/wrappers/Will.js
+++ b/app/wrappers/Will.js
@@ -18,6 +18,10 @@ class Will {
     hasCodicilsDate() {
         return this.will.isCodicilsDate === commonContent.yes;
     }
+
+    codicilsNumber() {
+        return this.will.codicilsNumber ? this.will.codicilsNumber : 0;
+    }
 }
 
 module.exports = Will;

--- a/test/component/testDocumentsPage.js
+++ b/test/component/testDocumentsPage.js
@@ -1,6 +1,6 @@
-const TestWrapper = require('test/util/TestWrapper'),
-    config = require('app/config'),
-    ThankYou = require('app/steps/ui/thankyou/index.js');
+const TestWrapper = require('test/util/TestWrapper');
+const config = require('app/config');
+const ThankYou = require('app/steps/ui/thankyou/index.js');
 
 describe('documents-page', () => {
     let testWrapper;
@@ -140,6 +140,31 @@ describe('documents-page', () => {
                         codicilsNumber: 1
                     };
                     testWrapper.testContent(done, excludeKeys, contentData);
+                });
+        });
+
+        it('test correct content loaded on the page, no codicils, single executor, specified registry address', (done) => {
+            const sessionData = {
+                executors: {},
+                documents: {
+                    registryAddress: '1 Red Street\nLondon\nO1 1OL'
+                }
+            };
+            testWrapper.agent.post('/prepare-session/form')
+                .send(sessionData)
+                .end(() => {
+                    const excludeKeys = [
+                        'checklist1-item2',
+                        'checklist2Header',
+                        'checklist2-item1',
+                        'checklist2-item2',
+                        'checklist3-item1-codicils',
+                        'checklist3-item3',
+                        'coverLetter-codicils',
+                        'checkboxLabel-codicils',
+                        'sendDocumentsAddress'
+                    ];
+                    testWrapper.testContent(done, excludeKeys);
                 });
         });
 

--- a/test/service-stubs/submit.js
+++ b/test/service-stubs/submit.js
@@ -2,18 +2,23 @@
 
 /* eslint no-console: 0 */
 
-const config = require('app/config'),
-    express = require('express'),
-    app = express(),
-    router = require('express').Router(),
-    SUBMIT_SERVICE_PORT = config.services.submit.port,
-    SUBMIT_SERVICE_PATH = config.services.submit.path;
+const config = require('app/config');
+const express = require('express');
+const app = express();
+const router = require('express').Router();
+const SUBMIT_SERVICE_PORT = config.services.submit.port;
+const SUBMIT_SERVICE_PATH = config.services.submit.path;
 
-router.post(SUBMIT_SERVICE_PATH, function (req, res) {
+router.post(SUBMIT_SERVICE_PATH, (req, res) => {
     res.status(200);
-    res.send('1234567890');
+    res.send({
+        'submissionReference': '1234',
+        'registrySequenceNumber': '10001',
+        'address': 'Test Address Line 1\nTest Address Line 2\nTest Address Postcode'
+    });
 });
-router.get('/health', function (req, res) {
+
+router.get('/health', (req, res) => {
     res.send({'status': 'UP'});
 });
 

--- a/test/unit/testDocumentsWrapper.js
+++ b/test/unit/testDocumentsWrapper.js
@@ -1,0 +1,29 @@
+const DocumentsWrapper = require('app/wrappers/Documents');
+const chai = require('chai');
+const expect = chai.expect;
+
+describe('Documents.js', () => {
+    describe('registryAddress()', () => {
+        it('should return the address when an address is available', (done) => {
+            const data = {registryAddress: 'Test Address Line 1\nTest Address Line 2\nTest Address Postcode'};
+            const documentsWrapper = new DocumentsWrapper(data);
+            expect(documentsWrapper.registryAddress()).to.equal(data.registryAddress);
+            done();
+        });
+
+        describe('should return an empty string', () => {
+            it('when there is no address property', (done) => {
+                const data = {};
+                const documentsWrapper = new DocumentsWrapper(data);
+                expect(documentsWrapper.registryAddress()).to.equal('');
+                done();
+            });
+
+            it('when there is no documents data', (done) => {
+                const documentsWrapper = new DocumentsWrapper();
+                expect(documentsWrapper.registryAddress()).to.equal('');
+                done();
+            });
+        });
+    });
+});

--- a/test/unit/testWillWrapper.js
+++ b/test/unit/testWillWrapper.js
@@ -12,18 +12,26 @@ describe('Will.js', () => {
             done();
         });
 
-        it('should return false when there are no codicils', (done) => {
-            const data = {codicils: commonContent.no};
-            const willWrapper = new WillWrapper(data);
-            expect(willWrapper.hasCodicils()).to.equal(false);
-            done();
-        });
+        describe('should return false', () => {
+            it('when there are no codicils', (done) => {
+                const data = {codicils: commonContent.no};
+                const willWrapper = new WillWrapper(data);
+                expect(willWrapper.hasCodicils()).to.equal(false);
+                done();
+            });
 
-        it('should return false when there is no will data', (done) => {
-            const data = {};
-            const willWrapper = new WillWrapper(data);
-            expect(willWrapper.hasCodicils()).to.equal(false);
-            done();
+            it('when there is no codicils property', (done) => {
+                const data = {};
+                const willWrapper = new WillWrapper(data);
+                expect(willWrapper.hasCodicils()).to.equal(false);
+                done();
+            });
+
+            it('when there is no will data', (done) => {
+                const willWrapper = new WillWrapper();
+                expect(willWrapper.hasCodicils()).to.equal(false);
+                done();
+            });
         });
     });
 
@@ -35,18 +43,26 @@ describe('Will.js', () => {
             done();
         });
 
-        it('should return false when there is no will date', (done) => {
-            const data = {isWillDate: commonContent.no};
-            const willWrapper = new WillWrapper(data);
-            expect(willWrapper.hasWillDate()).to.equal(false);
-            done();
-        });
+        describe('should return false', () => {
+            it('when there is no will date', (done) => {
+                const data = {isWillDate: commonContent.no};
+                const willWrapper = new WillWrapper(data);
+                expect(willWrapper.hasWillDate()).to.equal(false);
+                done();
+            });
 
-        it('should return false when there is no will data', (done) => {
-            const data = {};
-            const willWrapper = new WillWrapper(data);
-            expect(willWrapper.hasWillDate()).to.equal(false);
-            done();
+            it('when there is no isWIllDate property', (done) => {
+                const data = {};
+                const willWrapper = new WillWrapper(data);
+                expect(willWrapper.hasWillDate()).to.equal(false);
+                done();
+            });
+
+            it('when there is no will data', (done) => {
+                const willWrapper = new WillWrapper();
+                expect(willWrapper.hasWillDate()).to.equal(false);
+                done();
+            });
         });
     });
 
@@ -58,18 +74,50 @@ describe('Will.js', () => {
             done();
         });
 
-        it('should return false when there is no codicils date', (done) => {
-            const data = {isCodicilsDate: commonContent.no};
+        describe('should return false', () => {
+            it('when there is no codicils date', (done) => {
+                const data = {isCodicilsDate: commonContent.no};
+                const willWrapper = new WillWrapper(data);
+                expect(willWrapper.hasCodicilsDate()).to.equal(false);
+                done();
+            });
+
+            it('when isCodicilsDate property', (done) => {
+                const data = {};
+                const willWrapper = new WillWrapper(data);
+                expect(willWrapper.hasCodicilsDate()).to.equal(false);
+                done();
+            });
+
+            it('when there is no will data', (done) => {
+                const willWrapper = new WillWrapper();
+                expect(willWrapper.hasCodicilsDate()).to.equal(false);
+                done();
+            });
+        });
+    });
+
+    describe('codicilsNumber()', () => {
+        it('should return the number of codicils when there is a codicils number', (done) => {
+            const data = {codicilsNumber: 2};
             const willWrapper = new WillWrapper(data);
-            expect(willWrapper.hasCodicilsDate()).to.equal(false);
+            expect(willWrapper.codicilsNumber()).to.equal(2);
             done();
         });
 
-        it('should return false when there is no will data', (done) => {
-            const data = {};
-            const willWrapper = new WillWrapper(data);
-            expect(willWrapper.hasCodicilsDate()).to.equal(false);
-            done();
+        describe('should return 0', () => {
+            it('when there is no codicilsNumber property', (done) => {
+                const data = {};
+                const willWrapper = new WillWrapper(data);
+                expect(willWrapper.codicilsNumber()).to.equal(0);
+                done();
+            });
+
+            it('when there is no will data', (done) => {
+                const willWrapper = new WillWrapper();
+                expect(willWrapper.codicilsNumber()).to.equal(0);
+                done();
+            });
         });
     });
 });

--- a/test/util/TestWrapper.js
+++ b/test/util/TestWrapper.js
@@ -1,11 +1,11 @@
-const {forEach, filter, isEmpty, set, get, cloneDeep} = require('lodash'),
-    {expect, assert} = require('chai'),
-    app = require('app'),
-    routes = require('app/routes'),
-    config = require('app/config'),
-    request = require('supertest'),
-    journeyMap = require('app/core/journeyMap'),
-    {steps} = require('app/core/initSteps');
+const {forEach, filter, isEmpty, set, get, cloneDeep} = require('lodash');
+const {expect, assert} = require('chai');
+const app = require('app');
+const routes = require('app/routes');
+const config = require('app/config');
+const request = require('supertest');
+const journeyMap = require('app/core/journeyMap');
+const {steps} = require('app/core/initSteps');
 
 module.exports = class TestWrapper {
     constructor(stepName) {
@@ -90,6 +90,7 @@ module.exports = class TestWrapper {
     substituteContent(data, contentToSubstitute) {
         Object.entries(contentToSubstitute)
             .forEach(([key, contentValue]) => {
+                contentValue = contentValue.replace(/\n/g, '<br />\n');
                 forEach(contentValue.match(/\{(.*?)\}/g), (placeholder) => {
                     const placeholderRegex = new RegExp(placeholder, 'g');
                     placeholder = placeholder.replace(/[{}]/g, '');


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/PRO-2216

### Change description ###

**Add method to the will wrapper**
- Add codicilsNumber() to return the number of codicils on the application
- Add unit tests for codicilsNumber() method and improve other unit tests

**Add documents wrapper**
- Add registryAddress() method to get the address of the registry that the documents for the current application need to be sent to
- Add unit tests for registryAddress() method

**Update data returned from the submit stub**
- Change from submissionReference string to an object with the following properties
  - submissionReference
  - registrySequenceNumber
  - address
- Tidy code

**Update the registry address that is displayed on the documents page**
- Add logic to dsplay either the specified registry address or the default address if an address is not specified
- Add component test to test a specified address can be displayed
- Tidy code

**Update which returned data is saved after submitting an application**
- Update sendApplication() method to save the registryAddress to the session in addition to the submissionReference
- Tidy code

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```