### PR TITLE
Improve the validation check for executors with another name

### DIFF
--- a/app/steps/ui/executors/currentname/index.js
+++ b/app/steps/ui/executors/currentname/index.js
@@ -51,6 +51,6 @@ module.exports = class ExecutorCurrentName extends CollectionStep {
 
     isComplete(ctx) {
         const executorsWrapper = new ExecutorsWrapper(ctx);
-        return [executorsWrapper.hasOtherName().every(exec => exec.currentName), 'inProgress'];
+        return [executorsWrapper.executorsWithAnotherName().every(exec => exec.currentName), 'inProgress'];
     }
 };

--- a/app/wrappers/Executors.js
+++ b/app/wrappers/Executors.js
@@ -60,6 +60,10 @@ class Executors {
         return this.executorsList.some(executor => executor.hasOtherName === true);
     }
 
+    executorsWithAnotherName() {
+        return this.executorsList.filter(executor => executor.hasOtherName === true);
+    }
+
     areAllAliveExecutorsApplying() {
         return this.aliveExecutors().every(executor => executor.isApplying);
     }

--- a/test/unit/testExecutorsWrapper.js
+++ b/test/unit/testExecutorsWrapper.js
@@ -337,4 +337,40 @@ describe('Executors.js', () => {
             done();
         });
     });
+
+    describe('executorsWithAnotherName()', () => {
+        beforeEach(() => {
+            data = {
+                list: [
+                    {firstName: 'james', lastName: 'miller', isApplying: true, isApplicant: true},
+                    {fullname: 'ed brown', hasOtherName: true},
+                    {fullname: 'jake smith', has: true}
+                ]
+            };
+        });
+
+        it('should return a list of executors with another name', (done) => {
+            const executorsWrapper = new ExecutorsWrapper(data);
+            expect(executorsWrapper.executorsWithAnotherName()).to.deep.equal([
+                {fullname: 'ed brown', hasOtherName: true}
+            ]);
+            done();
+        });
+
+        describe('should return an empty list', () => {
+            it('when no executors have another name', (done) => {
+                data.list[1].hasOtherName = false;
+                const executorsWrapper = new ExecutorsWrapper(data);
+                expect(executorsWrapper.executorsWithAnotherName()).to.deep.equal([]);
+                done();
+            });
+
+            it('when there is no executor data', (done) => {
+                const data = {};
+                const executorsWrapper = new ExecutorsWrapper(data);
+                expect(executorsWrapper.executorsWithAnotherName()).to.deep.equal([]);
+                done();
+            });
+        });
+    });
 });


### PR DESCRIPTION
### Change description ###

We need to check if executors with another name have the other name set. If no executors name another name and hence return an empty list then the every function will return true.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```