### PR TITLE
PRO-2595 - CNP: Add smoke test for probate fronted to get git hash in health end point

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ coverage
 /test/end-to-end/output/**
 package-lock.json
 yarn-error.log
+git.properties.json

--- a/app/healthcheck.js
+++ b/app/healthcheck.js
@@ -6,17 +6,10 @@ const {map} = require('lodash');
 const url = require('url');
 const router = require('express').Router();
 const os = require('os');
-const childProcess = require('child_process');
-const logger = require('app/components/logger')();
+const gitProperties = require('git.properties');
 const gitRevision = process.env.GIT_REVISION;
 const osHostname = os.hostname();
-let gitHashString;
-try {
-    const gitHash = childProcess.execSync('git rev-parse HEAD');
-    gitHashString = gitHash.toString().trim();
-} catch (err) {
-    logger.error(err.toString());
-}
+const gitCommitId = gitProperties.git.commit.id;
 
 const getServiceHealthUrl = (serviceUrl) => {
     serviceUrl = url.parse(serviceUrl);
@@ -48,7 +41,7 @@ router.get('/', (req, res) => {
             'uptime': process.uptime(),
             'host': osHostname,
             'version': gitRevision,
-            'hash': gitHashString,
+            gitCommitId,
             downstream
         });
     });
@@ -57,4 +50,4 @@ router.get('/', (req, res) => {
 module.exports = router;
 module.exports.getServiceHealthUrl = getServiceHealthUrl;
 module.exports.osHostname = osHostname;
-module.exports.gitHashString = gitHashString;
+module.exports.gitCommitId = gitCommitId;

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "node": ">=8.9"
   },
   "scripts": {
-    "setup": "NODE_PATH=. npm run sass",
+    "setup": "NODE_PATH=. npm run sass && npm run git-info",
     "start": "NODE_PATH=. node server.js",
     "debug": "NODE_PATH=. node inspect server.js",
     "prestart:dev": "npm run sass:watch",
@@ -34,6 +34,7 @@
     "test:coverage": "NODE_ENV=test NODE_PATH=. istanbul cover _mocha './test/**/test*.js'",
     "test-coverage": "NODE_ENV=test NODE_PATH=. istanbul cover _mocha './test/**/test*.js'",
     "sonar-scanner": "node_modules/sonar-scanner/bin/sonar-scanner",
+    "git-info": "node-git-info-json",
     "//": "The below scripts are just stubs, dont use them in production",
     "s2s-stub": "NODE_PATH=. node test/service-stubs/idam.js",
     "submit-stub": "NODE_PATH=. node test/service-stubs/submit.js",
@@ -67,6 +68,7 @@
     "mocha-lcov-reporter": "^1.3.0",
     "moment": "^2.20.1",
     "node-fetch": "^1.6.3",
+    "node-git-info-json": "^0.1.1",
     "node-sass": "^4.5.3",
     "numeral": "^2.0.6",
     "nunjucks": "^3.0.1",

--- a/test/unit/testHealthcheck.js
+++ b/test/unit/testHealthcheck.js
@@ -34,7 +34,7 @@ describe('healthcheck.js', () => {
                 expect(res.body).to.have.property('name').and.equal(config.service.name);
                 expect(res.body).to.have.property('status').and.equal('UP');
                 expect(res.body).to.have.property('host').and.equal(healthcheck.osHostname);
-                expect(res.body).to.have.property('hash').and.equal(healthcheck.gitHashString);
+                expect(res.body).to.have.property('gitCommitId').and.equal(healthcheck.gitCommitId);
                 done();
             });
         });


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/PRO-2595

### Change description ###

**Improve git commit id detection**

The git commit id now comes from a `git.properties.json` file which is generated on setup, instead of being retrieved from the `.git` directory, which isn't available in production

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```