### PR TITLE
Create a stub for the address lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ By navigating to [https://localhost:3000](https://localhost:3000) you can partia
 
 To complete an end to end journey on the application locally without building the other services, you can run the following command which utilises stubs to mimic certain actions carried out during an end to end journey:
 
-`$ yarn start & yarn submit-stub & yarn persistence-stub & yarn business-stub & yarn payment-stub`
+`$ yarn start & yarn submit-stub & yarn persistence-stub & yarn business-stub & yarn payment-stub & yarn find-address-stub`
 
 As before, the application can be completed locally at [https://localhost:3000](https://localhost:3000).
 

--- a/app/config.js
+++ b/app/config.js
@@ -18,9 +18,11 @@ module.exports = {
     },
     services: {
         postcode: {
-            url: process.env.POSTCODE_SERVICE_URL,
+            url: process.env.POSTCODE_SERVICE_URL || 'http://localhost:8585/find-address',
             token: process.env.POSTCODE_SERVICE_TOKEN,
-            proxy: process.env.http_proxy
+            proxy: process.env.http_proxy,
+            port: 8585,
+            path: '/find-address'
         },
         validation: {
             url: process.env.VALIDATION_SERVICE_URL || 'http://localhost:8080/validate'

--- a/package.json
+++ b/package.json
@@ -35,12 +35,13 @@
     "test-coverage": "NODE_ENV=test NODE_PATH=. istanbul cover _mocha './test/**/test*.js'",
     "sonar-scanner": "node_modules/sonar-scanner/bin/sonar-scanner",
     "git-info": "node-git-info-json",
-    "//": "The below scripts are just stubs, dont use them in production",
+    "//": "The below scripts are just stubs, don't use them in production",
     "s2s-stub": "NODE_PATH=. node test/service-stubs/idam.js",
     "submit-stub": "NODE_PATH=. node test/service-stubs/submit.js",
     "persistence-stub": "NODE_PATH=. node test/service-stubs/persistence.js",
     "business-stub": "NODE_PATH=. node test/service-stubs/business.js",
-    "payment-stub": "NODE_PATH=. node test/service-stubs/payment.js"
+    "payment-stub": "NODE_PATH=. node test/service-stubs/payment.js",
+    "find-address-stub": "NODE_PATH=. node test/service-stubs/find-address.js"
   },
   "dependencies": {
     "@hmcts/nodejs-logging": "^3.0.0",

--- a/test/data/find-address.json
+++ b/test/data/find-address.json
@@ -1,0 +1,10 @@
+[{
+  "building_number": "102",
+  "organisation_name": "MINISTRY OF JUSTICE",
+  "post_town": "LONDON",
+  "postcode": "SW1H 9AJ",
+  "sub_building_name": "SEVENTH FLOOR",
+  "thoroughfare_name": "PETTY FRANCE",
+  "uprn": "10033604583",
+  "formatted_address": "Ministry of Justice\nSeventh Floor\n102 Petty France\nLondon\nSW1H 9AJ"
+}]

--- a/test/service-stubs/find-address.js
+++ b/test/service-stubs/find-address.js
@@ -1,0 +1,24 @@
+'use strict';
+
+/* eslint no-console: 0 */
+
+const config = require('app/config');
+const express = require('express');
+const app = express();
+const router = require('express').Router();
+const validData = require('test/data/find-address');
+const FIND_ADDRESS_PORT = config.services.postcode.port;
+const FIND_ADDRESS_PATH = config.services.postcode.path;
+
+router.get(FIND_ADDRESS_PATH, (req, res) => {
+    const data = req.query.postcode === 'VALID' ? validData : [];
+    res.status(200);
+    res.send(data);
+});
+
+app.use(router);
+
+console.log(`Listening on: ${FIND_ADDRESS_PORT}`);
+const server = app.listen(FIND_ADDRESS_PORT);
+
+module.exports = server;


### PR DESCRIPTION
### Change description ###

**Create a stub for the address lookup**
Currently the address lookup doesn't work locally and we don't want to have to rely on an external service for this to work so this creates a stub to return an address.

- Enter `VALID` in the postcode field to return an address
- Enter anything else to return an error

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```