### PR TITLE
Pro 2704 b cookie banner content missing

### DIFF
--- a/app.js
+++ b/app.js
@@ -23,6 +23,7 @@ const InviteSecurity = require(__dirname + '/app/invite');
 const fs = require('fs');
 const https = require('https');
 const appInsights = require('applicationinsights');
+const commonContent = require('app/resources/en/translation/common');
 
 exports.init = function() {
 
@@ -160,9 +161,8 @@ exports.init = function() {
 
 // Add variables that are available in all views
     app.use(function (req, res, next) {
-        res.locals.serviceName = config.service.name;
-        res.locals.serviceVersion = config.service.version;
-        res.locals.cookieText = config.app.cookieText;
+        res.locals.serviceName = commonContent.serviceName;
+        res.locals.cookieText = commonContent.cookieText;
         res.locals.releaseVersion = 'v' + releaseVersion;
         next();
     });

--- a/app.js
+++ b/app.js
@@ -162,7 +162,7 @@ exports.init = function() {
     app.use(function (req, res, next) {
         res.locals.serviceName = config.service.name;
         res.locals.serviceVersion = config.service.version;
-        res.locals.cookieText = config.cookieText;
+        res.locals.cookieText = config.app.cookieText;
         res.locals.releaseVersion = 'v' + releaseVersion;
         next();
     });

--- a/app/config.js
+++ b/app/config.js
@@ -2,10 +2,6 @@ module.exports = {
     environment: process.env.REFORM_ENVIRONMENT,
     nodeEnvironment: process.env.NODE_ENV,
     gitRevision: process.env.GIT_REVISION,
-    service: {
-        name: 'Apply for probate',
-        version: ''
-    },
     app: {
         username: process.env.USERNAME,
         password: process.env.PASSWORD,
@@ -13,8 +9,7 @@ module.exports = {
         useHttps: process.env.USE_HTTPS || 'false',
         useIDAM: process.env.USE_IDAM || 'false',
         port: process.env.PORT || '3000',
-        useCSRFProtection: 'true',
-        cookieText: 'GOV.UK uses cookies to make the site simpler. <a href="/cookies" rel="noopener" title="Find out more about cookies">Find out more about cookies</a>'
+        useCSRFProtection: 'true'
     },
     services: {
         postcode: {

--- a/app/config.js
+++ b/app/config.js
@@ -14,7 +14,7 @@ module.exports = {
         useIDAM: process.env.USE_IDAM || 'false',
         port: process.env.PORT || '3000',
         useCSRFProtection: 'true',
-        cookieText: 'GOV.UK uses cookies to make the site simpler. <a href="http://gov.uk/help/cookies" title="Find out more about cookies">Find out more about cookies</a>'
+        cookieText: 'GOV.UK uses cookies to make the site simpler. <a href="/cookies" rel="noopener" title="Find out more about cookies">Find out more about cookies</a>'
     },
     services: {
         postcode: {

--- a/app/healthcheck.js
+++ b/app/healthcheck.js
@@ -10,6 +10,7 @@ const gitProperties = require('git.properties');
 const gitRevision = process.env.GIT_REVISION;
 const osHostname = os.hostname();
 const gitCommitId = gitProperties.git.commit.id;
+const commonContent = require('app/resources/en/translation/common');
 
 const getServiceHealthUrl = (serviceUrl) => {
     serviceUrl = url.parse(serviceUrl);
@@ -36,7 +37,7 @@ router.get('/', (req, res) => {
     const healthPromises = createPromisesList(services);
     Promise.all(healthPromises).then(downstream => {
         res.json({
-            'name': config.service.name,
+            'name': commonContent.serviceName,
             'status': 'UP',
             'uptime': process.uptime(),
             'host': osHostname,

--- a/app/resources/en/translation/common.json
+++ b/app/resources/en/translation/common.json
@@ -12,7 +12,7 @@
   "acceptAndContinue": "Accept and continue",
   "send": "Send",
   "ogl": "All content is available under the <a href=\"https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/\" rel=\"license\">Open Government Licence v3.0</a>, except where otherwise stated",
-  "cookieText": "GOV.UK uses cookies to make the site simpler. <a href=\"#\" title=\"Find out more about cookies\">Find out more about cookies</a>",
+  "cookieText": "GOV.UK uses cookies to make the site simpler. <a href=\"/cookies\" rel=\"noopener\" title=\"Find out more about cookies\">Find out more about cookies</a>",
   "errorSummaryHeading": "There was a problem",
   "numberBelow21" : "first,second,third,fourth,fifth,sixth,seventh,eighth,ninth,tenth,eleventh,twelfth,thirteenth,fourteenth,fifteenth,sixteenth,seventeenth,eighteenth,nineteenth,twentieth",
   "months": "January, February, March, April, May, June, July, August, September, October, November, December",

--- a/test/config.js
+++ b/test/config.js
@@ -18,7 +18,7 @@ module.exports = {
     TestEnvMobileNumber: process.env.TEST_MOBILE_NUMBER,
     s2sStubErrorSequence: '000',
     links: {
-        cookies: 'https://www.gov.uk/help/cookies',
+        cookies: '/cookies',
         terms: process.env.TERMS_AND_CONDITIONS,
         survey: process.env.SURVEY,
         surveyEndOfApplication: process.env.SURVEY_END_OF_APPLICATION,

--- a/test/end-to-end/paths/cookieBanner.js
+++ b/test/end-to-end/paths/cookieBanner.js
@@ -1,8 +1,7 @@
-const commonContent = require('app/resources/en/translation/common.json');
 const TestConfigurator = new (require('test/end-to-end/helpers/TestConfigurator'))();
 const testConfig = require('test/config.js');
 
-Feature('Cookies');
+Feature('Cookie Banner');
 
 // eslint complains that the Before/After are not used but they are by codeceptjs
 // so we have to tell eslint to not validate these
@@ -16,14 +15,16 @@ After(() => {
     TestConfigurator.getAfter();
 });
 
-Scenario(TestConfigurator.idamInUseText('Check that the pages display a cookie link'), (I) => {
+Scenario(TestConfigurator.idamInUseText('Check that the pages display a cookie banner with link'), (I) => {
 
     // IDAM
     I.authenticateWithIdamIfAvailable();
 
     I.startApplication();
 
-    I.click(commonContent.cookies);
-    I.waitForText('Services and information', 60);
+    // Click the cookie banner link that appears at the top (Electron browser starts afresh so we don't have to clear the cookie to make the banner show)
+    I.click('a[href=\'' + testConfig.links.cookies + '\']');
+
+    I.waitForText('How cookies are used in this service', 60);
     I.seeCurrentUrlEquals(testConfig.links.cookies);
 });

--- a/test/unit/testHealthcheck.js
+++ b/test/unit/testHealthcheck.js
@@ -3,6 +3,7 @@ const app = require('app');
 const request = require('supertest');
 const config = require('app/config');
 const healthcheck = require('app/healthcheck');
+const commonContent = require('app/resources/en/translation/common');
 
 describe('healthcheck.js', () => {
     describe('getServiceHealthUrl()', () => {
@@ -32,7 +33,7 @@ describe('healthcheck.js', () => {
                 if (err) {
                     throw err;
                 }
-                expect(res.body).to.have.property('name').and.equal(config.service.name);
+                expect(res.body).to.have.property('name').and.equal(commonContent.serviceName);
                 expect(res.body).to.have.property('status').and.equal('UP');
                 expect(res.body).to.have.property('host').and.equal(healthcheck.osHostname);
                 expect(res.body).to.have.property('gitCommitId').and.equal(healthcheck.gitCommitId);


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PRO-2704


### Change description ###
Correct cookie banner so it shows correctly plus other code tidying
    
    - Removed service name from app.js. It now uses the serviceName
    in common.json (this is for multi-language).
    
    - Removed version info from app.js as it wasn't used.
    
    - Removed service object from config.js as it's no longer being used.
    
    - Cookies link updated in test/config.js
    
    - Healthcheck and testHealthcheck now refer to serviceName from
    common.json (note this is the English version of content, as the service
    name written in Welsh in Healthcheck status could confuse).


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
