### PR TITLE
PRO-2704-Fix-eslint-issue-caused-by-pause-statements

### DIFF
--- a/test/end-to-end/paths/multipleExecutorsPath.js
+++ b/test/end-to-end/paths/multipleExecutorsPath.js
@@ -128,9 +128,7 @@ Scenario(TestConfigurator.idamInUseText('Multiple Executors Journey - Main appli
 
     //Retrieve the email urls for additional executors
     I.amOnPage(testConfig.TestInviteIdListUrl);
-    pause();
     grabIds = yield I.grabTextFrom('body');
-    pause();
 });
 
 Scenario(TestConfigurator.idamInUseText('Additional Executor(s) Agree to Statement of Truth'), function* (I) {


### PR DESCRIPTION
2 pause statements were left in the multipleExecutorsPath.js test file
which were causing eslint to fail.  They have now been removed.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
