### PR TITLE
Fix the healthcheck test

### DIFF
--- a/app/healthcheck.js
+++ b/app/healthcheck.js
@@ -7,6 +7,7 @@ const router = require('express').Router();
 const os = require('os');
 const gitProperties = require('git.properties');
 const FormatUrl = require('app/utils/FormatUrl');
+const commonContent = require('app/resources/en/translation/common');
 const gitRevision = process.env.GIT_REVISION;
 const osHostname = os.hostname();
 const gitCommitId = gitProperties.git.commit.id;
@@ -32,7 +33,7 @@ router.get('/', (req, res) => {
     const healthPromises = createPromisesList(services);
     Promise.all(healthPromises).then(downstream => {
         res.json({
-            'name': config.service.name,
+            'name': commonContent.serviceName,
             'status': 'UP',
             'uptime': process.uptime(),
             'host': osHostname,


### PR DESCRIPTION
### Change description ###

**Fix the healthcheck test which was failing after merging the cnp branches into master**

The test broke because the `/health` endpoint wasn't updated after the service name was moved from the config file into the common content file

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```