### PR TITLE
PRO-3045: Adding health status UP to s2s-stub for verifying app healt…

### DIFF
--- a/test/service-stubs/idam.js
+++ b/test/service-stubs/idam.js
@@ -37,6 +37,15 @@ router.post('/lease', function (req, res) {
 
 });
 
+router.get('/health', function (req, res) {
+    console.log(req.headers);
+    console.log(req.body);
+    
+	res.status(200);
+    res.setHeader('Content-Type', 'application/json');
+    res.send(JSON.stringify({ status: 'OK' }));
+})
+	
 app.use(router);
 
 // start the app

--- a/test/service-stubs/idam.js
+++ b/test/service-stubs/idam.js
@@ -42,7 +42,7 @@ router.get('/health', (req, res) => {
     res.setHeader('Content-Type', 'application/json');
     res.send({'status': 'UP'});
 });
-	
+
 app.use(router);
 
 // start the app

--- a/test/service-stubs/idam.js
+++ b/test/service-stubs/idam.js
@@ -37,14 +37,11 @@ router.post('/lease', function (req, res) {
 
 });
 
-router.get('/health', function (req, res) {
-    console.log(req.headers);
-    console.log(req.body);
-    
-	res.status(200);
+router.get('/health', (req, res) => {
+    res.status(200);
     res.setHeader('Content-Type', 'application/json');
-    res.send(JSON.stringify({ status: 'UP' }));
-})
+    res.send({'status': 'UP'});
+});
 	
 app.use(router);
 

--- a/test/service-stubs/idam.js
+++ b/test/service-stubs/idam.js
@@ -43,7 +43,7 @@ router.get('/health', function (req, res) {
     
 	res.status(200);
     res.setHeader('Content-Type', 'application/json');
-    res.send(JSON.stringify({ status: 'OK' }));
+    res.send(JSON.stringify({ status: 'UP' }));
 })
 	
 app.use(router);


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PRO-3045

### Change description ###
Basic change to add a health endpoint to the s2s-stub. This is required to get a health status for all probate applications to be 'UP'. 

The trigger for this is the submit service includes an external JAR file which calls the s2s service health endpoint - not sure if this is necessary - however in development this endpoint in the s2s-stub doesn't exist to the submit service is always down. Adding the health endpoint means the submit service is now healthy.

Alternatively the s2s dependancy in the submit service could also be disabled although I'm not entirely sure why the submit service is using this service if the frontend calls the s2s service directly.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
