### PR TITLE
PRO-3132 - Probate-frontend health check is showing UP even though some of the dependent services are down

### DIFF
--- a/app/healthcheck.js
+++ b/app/healthcheck.js
@@ -15,7 +15,7 @@ router.get('/', (req, res) => {
         healthcheck.getDownstream(healthcheck.info, infoDownstream => {
             return res.json({
                 name: commonContent.serviceName,
-                status: 'UP',
+                status: healthcheck.status(healthDownstream),
                 uptime: process.uptime(),
                 host: osHostname,
                 version: gitRevision,

--- a/app/utils/Healthcheck.js
+++ b/app/utils/Healthcheck.js
@@ -3,6 +3,8 @@
 const FormatUrl = require('app/utils/FormatUrl');
 const {asyncFetch, fetchOptions} = require('app/components/api-utils');
 const config = require('app/config');
+const statusUp = 'UP';
+const statusDown = 'DOWN';
 
 class Healthcheck {
     formatUrl(endpoint) {
@@ -28,7 +30,7 @@ class Healthcheck {
 
     health({err, service, json}) {
         if (err) {
-            return {name: service.name, status: 'DOWN', error: err.toString()};
+            return {name: service.name, status: statusDown, error: err.toString()};
         }
         return {name: service.name, status: json.status};
     }
@@ -45,6 +47,10 @@ class Healthcheck {
         const services = this.createServicesList(url, config.services);
         const promises = this.createPromisesList(services, type);
         Promise.all(promises).then(downstream => callback(downstream));
+    }
+
+    status(healthDownstream) {
+        return healthDownstream.every(service => service.status === statusUp) ? statusUp : statusDown;
     }
 
     mergeInfoAndHealthData(healthDownstream, infoDownstream) {

--- a/test/unit/testHealthcheck.js
+++ b/test/unit/testHealthcheck.js
@@ -17,7 +17,7 @@ describe('healthcheck.js', () => {
                     throw err;
                 }
                 expect(res.body).to.have.property('name').and.equal(commonContent.serviceName);
-                expect(res.body).to.have.property('status').and.equal('UP');
+                expect(res.body).to.have.property('status').and.equal('DOWN');
                 expect(res.body).to.have.property('host').and.equal(healthcheck.osHostname);
                 expect(res.body).to.have.property('gitCommitId').and.equal(healthcheck.gitCommitId);
                 done();

--- a/test/unit/testHealthcheckUtil.js
+++ b/test/unit/testHealthcheckUtil.js
@@ -171,6 +171,22 @@ describe('Healthcheck.js', () => {
         after(() => stopStubs());
     });
 
+    describe('status()', () => {
+        it('should return UP when all the downstream services are up', (done) => {
+            const healthcheck = new Healthcheck();
+            const status = healthcheck.status([{status: 'UP'}, {status: 'UP'}]);
+            expect(status).to.equal('UP');
+            done();
+        });
+
+        it('should return DOWN when any of the downstream services are down', (done) => {
+            const healthcheck = new Healthcheck();
+            const status = healthcheck.status([{status: 'DOWN'}, {status: 'UP'}]);
+            expect(status).to.equal('DOWN');
+            done();
+        });
+    });
+
     describe('mergeInfoAndHealthData()', () => {
         it('should return a list of merged health and info data', (done) => {
             const healthcheck = new Healthcheck();


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/PRO-3132

### Change description ###

Make `/health` status dynamic based on the status of downstream services

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```