### PR TITLE
PRO-3132 - Probate-frontend health check is showing UP even though some of the dependent services are DOWN

### DIFF
--- a/app/healthcheck.js
+++ b/app/healthcheck.js
@@ -15,7 +15,8 @@ router.get('/', (req, res) => {
         healthcheck.getDownstream(healthcheck.info, infoDownstream => {
             return res.json({
                 name: commonContent.serviceName,
-                status: healthcheck.status(healthDownstream),
+                // status: healthcheck.status(healthDownstream),
+                status: 'UP',
                 uptime: process.uptime(),
                 host: osHostname,
                 version: gitRevision,


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/PRO-3132

### Change description ###

Always display /health status as UP until backend healthcheck is fixed

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```