### PR TITLE
PRO-2752: Open feedback link in new tab/window

### DIFF
--- a/app/resources/en/translation/common.json
+++ b/app/resources/en/translation/common.json
@@ -1,6 +1,6 @@
 {
-  "phase": "Alpha",
-  "feedback": "This is a new service – your <a href=\"#\">feedback</a> will help us to improve it.",
+  "phase": "Beta",
+  "feedback": "This is a new service – your <a aria-label=\"This link will open in a new tab. You&rsquo;ll need to return to this tab to continue with your application.\" href=\"{smartSurveyFeedbackUrl}?pageurl={currentPageUrl}\" target=\"_blank\" rel=\"external noopener\">feedback</a> will help us to improve it.",
   "serviceName": "Apply for probate",
   "start": "Start now",
   "back": "Back",

--- a/app/views/includes/phase_banner_alpha.html
+++ b/app/views/includes/phase_banner_alpha.html
@@ -1,6 +1,6 @@
 <div class="phase-banner-alpha">
   <p>
-    <strong class="phase-tag">ALPHA</strong>
-    <span>This is a new service – your <a href="#">feedback</a> will help us to improve it.</span>
+    <strong class="phase-tag">{{common.phase}}</strong>
+    <span>{{common.feedback | replace('{smartSurveyFeedbackUrl}', links.survey) | replace('{currentPageUrl}', pageUrl) | safe}}</span>
   </p>
 </div>

--- a/app/views/includes/phase_banner_alpha.html
+++ b/app/views/includes/phase_banner_alpha.html
@@ -1,6 +1,0 @@
-<div class="phase-banner-alpha">
-  <p>
-    <strong class="phase-tag">{{common.phase}}</strong>
-    <span>{{common.feedback | replace('{smartSurveyFeedbackUrl}', links.survey) | replace('{currentPageUrl}', pageUrl) | safe}}</span>
-  </p>
-</div>

--- a/app/views/includes/phase_banner_beta.html
+++ b/app/views/includes/phase_banner_beta.html
@@ -1,6 +1,6 @@
 <div class="phase-banner-beta">
   <p>
-    <strong class="phase-tag">BETA</strong>
-    <span>This is a new service – your <a href="{{links.survey}}?pageurl={{pageUrl}}">feedback</a> will help us to improve it.</span>
+    <strong class="phase-tag">{{common.phase}}</strong>
+    <span>{{common.feedback | replace('{smartSurveyFeedbackUrl}', links.survey) | replace('{currentPageUrl}', pageUrl) | safe}}</span>
   </p>
 </div>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PRO-2752

### Change description ###
Accessibility changes for Public Beta:  Open feedback link in new tab/window

- Added aria-label element to feedback link to assist with accessibility
- Also moved all phase banner and feedback content to common.json


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
