### PR TITLE
PRO-2789 - Change legend on declaration and documents page to match title

### DIFF
--- a/app/steps/ui/declaration/template.html
+++ b/app/steps/ui/declaration/template.html
@@ -65,9 +65,10 @@
     </div>
 
     {{ checkbox(
-        name='declarationCheckbox',
-        field= fields.declarationCheckbox,
-        text= fields.declaration.value.accept
+        name = 'declarationCheckbox',
+        field = fields.declarationCheckbox,
+        text = fields.declaration.value.accept,
+        legend = content.title
     ) }}
 
     <div class="notice">

--- a/app/steps/ui/documents/template.html
+++ b/app/steps/ui/documents/template.html
@@ -65,9 +65,10 @@
     <p>{{ fields.registryAddress.value | safe | nl2br }}</p>
 
     {{ checkbox(
-        name='sentDocuments',
-        field=fields.sentDocuments,
-        text=content["checkboxLabel" + codicilsSuffix]
+        name = 'sentDocuments',
+        field = fields.sentDocuments,
+        text = content["checkboxLabel" + codicilsSuffix],
+        legend = content.title
     ) }}
 
     <div class="form-group">

--- a/app/views/widgets/checkboxes.html
+++ b/app/views/widgets/checkboxes.html
@@ -1,9 +1,8 @@
 {% from "widgets/fielderror.html" import fieldError %}
 
-{% macro checkbox(name, field, text, disabled) %}
-
+{% macro checkbox(name, field, text, disabled, legend) %}
 <fieldset class="form-group {{ 'form-group-error' if field.error }}">
-    <legend class="visually-hidden">{{text | safe}}</legend>
+    <legend class="visually-hidden">{{legend | safe}}</legend>
 
     {{ fieldError(field) }}
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PRO-2789


### Change description ###
- For consistency it has been decided to keep the legends (their simple
removal causes our Pa11y tests to fail because the checkbox is contained
in a fieldset which requires a legend)

- The content of the legend has been changed to match the title of the
page


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
