### PR TITLE
PRO-2134: Implement Removal of Other Executors

### DIFF
--- a/app/steps/ui/executors/applying/index.js
+++ b/app/steps/ui/executors/applying/index.js
@@ -15,4 +15,16 @@ module.exports = class ExecutorsApplying extends ValidationStep {
         };
         return nextStepOptions;
     }
+
+    handlePost(ctx) {
+        if (ctx.otherExecutorsApplying === 'No') {
+            ctx.list
+                .filter(executor => !executor.isApplicant)
+                .map(executor => {
+                    delete executor.isApplying;
+                    return executor;
+                });
+        }
+        return [ctx];
+    }
 };

--- a/app/steps/ui/executors/applying/index.js
+++ b/app/steps/ui/executors/applying/index.js
@@ -1,5 +1,6 @@
 const ValidationStep = require('app/core/steps/ValidationStep');
 const json = require('app/resources/en/translation/executors/applying.json');
+const ExecutorsWrapper = require('app/wrappers/Executors');
 
 module.exports = class ExecutorsApplying extends ValidationStep {
 
@@ -18,8 +19,8 @@ module.exports = class ExecutorsApplying extends ValidationStep {
 
     handlePost(ctx) {
         if (ctx.otherExecutorsApplying === 'No') {
-            ctx.list
-                .filter(executor => !executor.isApplicant)
+            const executorsWrapper = new ExecutorsWrapper(ctx);
+            executorsWrapper.executors(true)
                 .map(executor => {
                     delete executor.isApplying;
                     return executor;

--- a/app/steps/ui/executors/dealingwithestate/index.js
+++ b/app/steps/ui/executors/dealingwithestate/index.js
@@ -29,6 +29,8 @@ module.exports = class ExecutorsDealingWithEstate extends ValidationStep {
             delete data.diedBefore;
             delete data.notApplyingReason;
             delete data.notApplyingKey;
+        } else {
+            delete data.isApplying;
         }
         return data;
     }

--- a/app/steps/ui/executors/number/index.js
+++ b/app/steps/ui/executors/number/index.js
@@ -1,5 +1,6 @@
 const ValidationStep = require('app/core/steps/ValidationStep');
-const {get, dropRight} = require('lodash');
+const {get} = require('lodash');
+const ExecutorsWrapper = require('app/wrappers/Executors');
 module.exports = class ExecutorsNumber extends ValidationStep {
 
     static getUrl() {
@@ -14,6 +15,7 @@ module.exports = class ExecutorsNumber extends ValidationStep {
     }
 
     createExecutorList(ctx, formdata) {
+        const executorsWrapper = new ExecutorsWrapper(formdata.executors);
         ctx.list = get(ctx, 'list', []);
         ctx.list[0] = {
             firstName: get(formdata, 'applicant.firstName'),
@@ -24,7 +26,7 @@ module.exports = class ExecutorsNumber extends ValidationStep {
 
         if (ctx.list.length > ctx.executorsNumber) {
             return {
-                list: dropRight(ctx.list, ctx.list.length -1),
+                list: executorsWrapper.mainApplicant(),
                 executorsNumber: ctx.executorsNumber
             };
         }

--- a/app/steps/ui/executors/number/index.js
+++ b/app/steps/ui/executors/number/index.js
@@ -16,7 +16,7 @@ module.exports = class ExecutorsNumber extends ValidationStep {
 
     createExecutorList(ctx, formdata) {
         const executorsWrapper = new ExecutorsWrapper(formdata.executors);
-        ctx.list = get(ctx, 'list', []);
+        ctx.list = executorsWrapper.executors();
         ctx.list[0] = {
             firstName: get(formdata, 'applicant.firstName'),
             lastName: get(formdata, 'applicant.lastName'),

--- a/app/wrappers/DetectDataChange.js
+++ b/app/wrappers/DetectDataChange.js
@@ -49,7 +49,7 @@ class DetectDataChanges {
                     return this.isNotEqual(req.body.executorName, currentExecutors);
                 } else if (req.body.executorsApplying) {
                     const executorsApplying = executorsWrapper.executorsApplying(true).map(executor => executor.fullName);
-                    return this.isNotEqual(req.body.executorsApplying, executorsApplying) && req.session.haveAllExecutorsDeclared !== 'true';
+                    return this.isNotEqual(req.body.executorsApplying, executorsApplying);
                 }
             }
             return this.hasChanged(req.body, formdata[step.section]);

--- a/app/wrappers/DetectDataChange.js
+++ b/app/wrappers/DetectDataChange.js
@@ -47,6 +47,9 @@ class DetectDataChanges {
                 } else if (req.body.executorName) {
                     const currentExecutors = executorsWrapper.executors(true).map(executor => executor.fullName);
                     return this.isNotEqual(req.body.executorName, currentExecutors);
+                } else if (req.body.executorsApplying) {
+                    const executorsApplying = executorsWrapper.executorsApplying(true).map(executor => executor.fullName);
+                    return this.isNotEqual(req.body.executorsApplying, executorsApplying) && req.session.haveAllExecutorsDeclared !== 'true';
                 }
             }
             return this.hasChanged(req.body, formdata[step.section]);

--- a/app/wrappers/Executors.js
+++ b/app/wrappers/Executors.js
@@ -67,6 +67,10 @@ class Executors {
     areAllAliveExecutorsApplying() {
         return this.aliveExecutors().every(executor => executor.isApplying);
     }
+
+    mainApplicant() {
+        return this.executorsList.filter(executor => executor.isApplicant);
+    }
 }
 
 module.exports = Executors;

--- a/test/component/executors/testExecutorsApplying.js
+++ b/test/component/executors/testExecutorsApplying.js
@@ -37,7 +37,23 @@ describe('executorsapplying', () => {
 
         it(`test it redirects to executors roles if there are no other executors dealing with the estate: ${expectedNextUrlForExecRoles}`, (done) => {
             const data = {
-                'otherExecutorsApplying': 'No'
+                'otherExecutorsApplying': 'No',
+                'list': [
+                    {
+                        'lastName': 'the',
+                        'firstName': 'applicant',
+                        'isApplying': 'Yes',
+                        'isApplicant': true
+                    }, {
+                        isApplying: true,
+                        fullName: 'Ed Brown',
+                        address: '20 Green Street, London, L12 9LN'
+                    }, {
+                        isApplying: true,
+                        fullName: 'Dave Miller',
+                        address: '102 Petty Street, London, L12 9LN'
+                    }
+                ]
             };
             testWrapper.testRedirect(done, data, expectedNextUrlForExecRoles);
         });

--- a/test/unit/testActionStepRunner.js
+++ b/test/unit/testActionStepRunner.js
@@ -1,8 +1,10 @@
-const ActionStepRunner = require('app/core/runners/ActionStepRunner'),
-      sinon = require('sinon'),
-      chai = require('chai'),
-      expect = chai.expect,
-      sinonChai = require('sinon-chai');
+'use strict';
+
+const ActionStepRunner = require('app/core/runners/ActionStepRunner');
+const sinon = require('sinon');
+const chai = require('chai');
+const expect = chai.expect;
+const sinonChai = require('sinon-chai');
 
 chai.use(sinonChai);
 

--- a/test/unit/testAddressLookup.js
+++ b/test/unit/testAddressLookup.js
@@ -1,8 +1,10 @@
-const initSteps = require('app/core/initSteps'),
-    assert = require('chai').assert,
-    sinon = require('sinon'),
-    when = require('when'),
-    services = require('app/components/services');
+'use strict';
+
+const initSteps = require('app/core/initSteps');
+const assert = require('chai').assert;
+const sinon = require('sinon');
+const when = require('when');
+const services = require('app/components/services');
 const co = require('co');
 
 describe('AddressLookup', function () {

--- a/test/unit/testCoApplicant.js
+++ b/test/unit/testCoApplicant.js
@@ -1,6 +1,8 @@
-const initSteps = require('app/core/initSteps'),
-    assert = require('chai').assert,
-    {isNil} = require('lodash');
+'use strict';
+
+const initSteps = require('app/core/initSteps');
+const assert = require('chai').assert;
+const {isNil} = require('lodash');
 
 describe('Co-Applicant', function () {
 

--- a/test/unit/testDeceasedWrapper.js
+++ b/test/unit/testDeceasedWrapper.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const DeceasedWrapper = require('app/wrappers/Deceased');
 const commonContent = require('app/resources/en/translation/common');
 const chai = require('chai');

--- a/test/unit/testDetectDataChange.js
+++ b/test/unit/testDetectDataChange.js
@@ -123,12 +123,12 @@ describe('DetectDataChange.js', () => {
                                 isApplying: true
                             }, {
                                 isApplying: true,
-                                fullname: 'James Miller',
+                                fullName: 'James Miller',
                                 address: '11 Red Street, London, L21 1LL',
                                 email: 'jamesmiller@example.com'
                             }, {
                                 isApplying: true,
-                                fullname: 'Ed Brown',
+                                fullName: 'Ed Brown',
                                 address: '20 Green Street, London, L12 9LN'
                             }]
                         },
@@ -240,8 +240,8 @@ describe('DetectDataChange.js', () => {
 
             it('when executors applying tick boxes have not been changed', (done) => {
                 step.section = 'executors';
+                req.body.executorsApplying = ['James Miller', 'Ed Brown'];
                 const detectDataChange = new DetectDataChange();
-                req.session.haveAllExecutorsDeclared = 'true';
                 expect(detectDataChange.hasDataChanged(ctx, req, step)).to.equal(false);
                 done();
             });

--- a/test/unit/testDetectDataChange.js
+++ b/test/unit/testDetectDataChange.js
@@ -204,6 +204,16 @@ describe('DetectDataChange.js', () => {
                 expect(detectDataChange.hasDataChanged(ctx, req, step)).to.equal(true);
                 done();
             });
+
+            it('when executors applying tick boxes have been changed', (done) => {
+                req.session.form.executors.list[1].isApplying = false;
+                step.section = 'executors';
+                req.body = {executorsApplying: ['James Miller', 'Ed Brown']};
+                req.session.haveAllExecutorsDeclared = 'false';
+                const detectDataChange = new DetectDataChange();
+                expect(detectDataChange.hasDataChanged(ctx, req, step)).to.equal(true);
+                done();
+            });
         });
 
         describe('should return false', () => {
@@ -224,6 +234,14 @@ describe('DetectDataChange.js', () => {
             it('when all executors have declared', (done) => {
                 req.session.haveAllExecutorsDeclared = 'true';
                 const detectDataChange = new DetectDataChange();
+                expect(detectDataChange.hasDataChanged(ctx, req, step)).to.equal(false);
+                done();
+            });
+
+            it('when executors applying tick boxes have not been changed', (done) => {
+                step.section = 'executors';
+                const detectDataChange = new DetectDataChange();
+                req.session.haveAllExecutorsDeclared = 'true';
                 expect(detectDataChange.hasDataChanged(ctx, req, step)).to.equal(false);
                 done();
             });

--- a/test/unit/testExecutorAddress.js
+++ b/test/unit/testExecutorAddress.js
@@ -1,5 +1,5 @@
 /* eslint max-lines: ["error", 500] */
-
+'use strict';
 const initSteps = require('app/core/initSteps');
 const expect = require('chai').expect;
 const ExecutorsWrapper = require('app/wrappers/Executors');

--- a/test/unit/testExecutorsApplying.js
+++ b/test/unit/testExecutorsApplying.js
@@ -1,34 +1,48 @@
-const initSteps = require('app/core/initSteps'),
-    assert = require('chai').assert,
-    {isNil} = require('lodash');
+'use strict';
+
+const initSteps = require('app/core/initSteps');
+const assert = require('chai').assert;
+const {isNil} = require('lodash');
 
 describe('Executors-Applying', function () {
+    let ctx;
+    const ExecsApplying = initSteps([`${__dirname}/../../app/steps/action/`, `${__dirname}/../../app/steps/ui`]).ExecutorsApplying;
 
-    const ExecsApplying = initSteps([__dirname + '/../../app/steps/action/', __dirname + '/../../app/steps/ui']).ExecutorsApplying;
+    describe('handlePost', () => {
 
-    it('test executor isApplying flag is deleted', () => {
-        const ctx = {
-            'list': [
-                {
-                    'lastName': 'the',
-                    'firstName': 'applicant',
-                    'isApplying': 'Yes',
-                    'isApplicant': true
-                }, {
-                    isApplying: true,
-                    fullName: 'Ed Brown',
-                    address: '20 Green Street, London, L12 9LN'
-                }, {
-                    isApplying: true,
-                    fullName: 'Dave Miller',
-                    address: '102 Petty Street, London, L12 9LN'
-                }
-            ],
-            otherExecutorsApplying: 'No'
-        };
+        beforeEach(() => {
+            ctx = {
+                'list': [
+                    {
+                        'lastName': 'the',
+                        'firstName': 'applicant',
+                        'isApplying': 'Yes',
+                        'isApplicant': true
+                    }, {
+                        isApplying: true,
+                        fullName: 'Ed Brown',
+                        address: '20 Green Street, London, L12 9LN'
+                    }, {
+                        isApplying: true,
+                        fullName: 'Dave Miller',
+                        address: '102 Petty Street, London, L12 9LN'
+                    }
+                ],
+            };
+        });
 
-        ExecsApplying.handlePost(ctx);
-        assert.isTrue(isNil(ctx.list[1].isApplying));
-        assert.isTrue(isNil(ctx.list[2].isApplying));
+        it('test executor isApplying flag is deleted when No option is selected', () => {
+            ctx.otherExecutorsApplying = 'No';
+            ExecsApplying.handlePost(ctx);
+            assert.isTrue(isNil(ctx.list[1].isApplying));
+            assert.isTrue(isNil(ctx.list[2].isApplying));
+        });
+
+        it('test executor isApplying flag is true when Yes option selected', () => {
+            ctx.otherExecutorsApplying = 'Yes';
+            ExecsApplying.handlePost(ctx);
+            assert.isTrue(ctx.list[1].isApplying);
+            assert.isTrue(ctx.list[2].isApplying);
+        });
     });
 });

--- a/test/unit/testExecutorsApplying.js
+++ b/test/unit/testExecutorsApplying.js
@@ -1,0 +1,34 @@
+const initSteps = require('app/core/initSteps'),
+    assert = require('chai').assert,
+    {isNil} = require('lodash');
+
+describe('Executors-Applying', function () {
+
+    const ExecsApplying = initSteps([__dirname + '/../../app/steps/action/', __dirname + '/../../app/steps/ui']).ExecutorsApplying;
+
+    it('test executor isApplying flag is deleted', () => {
+        const ctx = {
+            'list': [
+                {
+                    'lastName': 'the',
+                    'firstName': 'applicant',
+                    'isApplying': 'Yes',
+                    'isApplicant': true
+                }, {
+                    isApplying: true,
+                    fullName: 'Ed Brown',
+                    address: '20 Green Street, London, L12 9LN'
+                }, {
+                    isApplying: true,
+                    fullName: 'Dave Miller',
+                    address: '102 Petty Street, London, L12 9LN'
+                }
+            ],
+            otherExecutorsApplying: 'No'
+        };
+
+        ExecsApplying.handlePost(ctx);
+        assert.isTrue(isNil(ctx.list[1].isApplying));
+        assert.isTrue(isNil(ctx.list[2].isApplying));
+    });
+});

--- a/test/unit/testExecutorsDealing.js
+++ b/test/unit/testExecutorsDealing.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const initSteps = require('app/core/initSteps');
-const assert = require('chai').assert;
+const {expect, assert} = require('chai');
 const {isNil} = require('lodash');
 
 describe('Executors-Applying', function () {
@@ -16,9 +16,10 @@ describe('Executors-Applying', function () {
             };
             ExecsDealing.pruneFormData(ctx);
             assert.isTrue(isNil(ctx.isApplying));
+            expect(ctx).to.deep.equal({fullName: 'Ed Brown'});
         });
 
-        it('test that isApplying flag is deleted when executor is not applying', () => {
+        it('test that notApplying data is pruned when executor is applying', () => {
             ctx = {
                 fullName: 'Ed Brown',
                 isApplying: true,
@@ -28,10 +29,10 @@ describe('Executors-Applying', function () {
                 notApplyingKey: 'not sure'
             };
             ExecsDealing.pruneFormData(ctx);
-            assert.isTrue(isNil(ctx.isDead));
-            assert.isTrue(isNil(ctx.diedBefore));
-            assert.isTrue(isNil(ctx.notApplyingReason));
-            assert.isTrue(isNil(ctx.notApplyingKey));
+            expect(ctx).to.deep.equal({
+                fullName: 'Ed Brown',
+                isApplying: true
+            });
         });
     });
 

--- a/test/unit/testExecutorsDealing.js
+++ b/test/unit/testExecutorsDealing.js
@@ -7,34 +7,64 @@ const {isNil} = require('lodash');
 describe('Executors-Applying', function () {
     let ctx;
     const ExecsDealing = initSteps([__dirname + '/../../app/steps/action/', __dirname + '/../../app/steps/ui']).ExecutorsDealingWithEstate;
-    beforeEach(() => {
-        ctx = {
-            list: [
-                {
-                    'lastName': 'the',
-                    'firstName': 'applicant',
-                    'isApplying': 'Yes',
-                    'isApplicant': true
-                }, {
-                    fullName: 'Ed Brown',
-                    address: '20 Green Street, London, L12 9LN'
-                }, {
-                    fullName: 'Dave Miller',
-                    address: '102 Petty Street, London, L12 9LN'
-                }
-            ],
-            executorsApplying: ['Dave Miller'],
-            executorsNumber: 3
-        };
+    describe('pruneFormData', () => {
+
+        it('test that isApplying flag is deleted when executor is not applying', () => {
+            ctx = {
+                fullName: 'Ed Brown',
+                isApplying: false
+            };
+            ExecsDealing.pruneFormData(ctx);
+            assert.isTrue(isNil(ctx.isApplying));
+        });
+
+        it('test that isApplying flag is deleted when executor is not applying', () => {
+            ctx = {
+                fullName: 'Ed Brown',
+                isApplying: true,
+                isDead: 'not sure',
+                diedBefore: 'not sure',
+                notApplyingReason: 'not sure',
+                notApplyingKey: 'not sure'
+            };
+            ExecsDealing.pruneFormData(ctx);
+            assert.isTrue(isNil(ctx.isDead));
+            assert.isTrue(isNil(ctx.diedBefore));
+            assert.isTrue(isNil(ctx.notApplyingReason));
+            assert.isTrue(isNil(ctx.notApplyingKey));
+        });
     });
 
-    it('test executors (with checkbox unchecked) isApplying flag is deleted', () => {
-        ExecsDealing.handlePost(ctx);
-        assert.isTrue(isNil(ctx.list[1].isApplying));
-    });
+    describe('handlePost', () => {
+        beforeEach(() => {
+            ctx = {
+                list: [
+                    {
+                        'lastName': 'the',
+                        'firstName': 'applicant',
+                        'isApplying': 'Yes',
+                        'isApplicant': true
+                    }, {
+                        fullName: 'Ed Brown',
+                        address: '20 Green Street, London, L12 9LN'
+                    }, {
+                        fullName: 'Dave Miller',
+                        address: '102 Petty Street, London, L12 9LN'
+                    }
+                ],
+                executorsApplying: ['Dave Miller'],
+                executorsNumber: 3
+            };
+        });
 
-    it('test executors (with checkbox checked) isApplying flag is set to true', () => {
-        ExecsDealing.handlePost(ctx);
-        assert.isTrue(ctx.list[2].isApplying);
+        it('test executors (with checkbox unchecked) isApplying flag is deleted', () => {
+            ExecsDealing.handlePost(ctx);
+            assert.isTrue(isNil(ctx.list[1].isApplying));
+        });
+
+        it('test executors (with checkbox checked) isApplying flag is set to true', () => {
+            ExecsDealing.handlePost(ctx);
+            assert.isTrue(ctx.list[2].isApplying);
+        });
     });
 });

--- a/test/unit/testExecutorsDealing.js
+++ b/test/unit/testExecutorsDealing.js
@@ -1,0 +1,38 @@
+const initSteps = require('app/core/initSteps'),
+    assert = require('chai').assert,
+    {isNil} = require('lodash');
+
+describe('Executors-Applying', function () {
+    let ctx;
+    const ExecsDealing = initSteps([__dirname + '/../../app/steps/action/', __dirname + '/../../app/steps/ui']).ExecutorsDealingWithEstate;
+    beforeEach(() => {
+        ctx = {
+            list: [
+                {
+                    'lastName': 'the',
+                    'firstName': 'applicant',
+                    'isApplying': 'Yes',
+                    'isApplicant': true
+                }, {
+                    fullName: 'Ed Brown',
+                    address: '20 Green Street, London, L12 9LN'
+                }, {
+                    fullName: 'Dave Miller',
+                    address: '102 Petty Street, London, L12 9LN'
+                }
+            ],
+            executorsApplying: ['Dave Miller'],
+            executorsNumber: 3
+        };
+    });
+
+    it('test executors (with checkbox unchecked) isApplying flag is deleted', () => {
+        ExecsDealing.handlePost(ctx);
+        assert.isTrue(isNil(ctx.list[1].isApplying));
+    });
+
+    it('test executors (with checkbox checked) isApplying flag is set to true', () => {
+        ExecsDealing.handlePost(ctx);
+        assert.isTrue(ctx.list[2].isApplying);
+    });
+});

--- a/test/unit/testExecutorsDealing.js
+++ b/test/unit/testExecutorsDealing.js
@@ -1,6 +1,8 @@
-const initSteps = require('app/core/initSteps'),
-    assert = require('chai').assert,
-    {isNil} = require('lodash');
+'use strict';
+
+const initSteps = require('app/core/initSteps');
+const assert = require('chai').assert;
+const {isNil} = require('lodash');
 
 describe('Executors-Applying', function () {
     let ctx;

--- a/test/unit/testExecutorsNumber.js
+++ b/test/unit/testExecutorsNumber.js
@@ -1,39 +1,83 @@
 'use strict';
 const initSteps = require('app/core/initSteps');
-const assert = require('chai').assert;
+const {expect, assert} = require('chai');
 
 describe('Executors-Applying', function () {
+    let ctx;
+    let formdata;
     const ExecsNumber = initSteps([`${__dirname}/../../app/steps/action/`, `${__dirname}/../../app/steps/ui`]).ExecutorsNumber;
 
     describe('createExecutorList', () => {
-
-        it('test only the main applicant is in the executors list when executors number is reduced', () => {
-            const ctx = {
-                executorsNumber: 2
-            };
-            const formdata = {
-                'applicant': {
+        beforeEach(() => {
+            ctx = {};
+            formdata = {
+                applicant: {
                     'firstName': 'Dave',
                     'lastName': 'Bassett'
                 },
-                list: [
-                    {
-                        'firstName': 'Dave',
-                        'lastName': 'Bassett',
-                        'isApplying': 'Yes',
-                        'isApplicant': true
-                    }, {
-                        fullName: 'Ed Brown'
-                    }, {
-                        fullName: 'Dave Miller'
-                    }
-                ],
+                executors: {
+                    list: [
+                        {
+                            'firstName': 'Dave',
+                            'lastName': 'Bassett',
+                            'isApplying': 'Yes',
+                            'isApplicant': true
+                        }, {
+                            fullName: 'Ed Brown'
+                        }, {
+                            fullName: 'Dave Miller'
+                        }
+                    ]
+                }
             };
-            ExecsNumber.createExecutorList(ctx, formdata);
+        });
+
+        it('test only the main applicant is in the executors list when executors number is reduced', () => {
+            ctx.executorsNumber = 2;
+            ctx = ExecsNumber.createExecutorList(ctx, formdata);
             assert.lengthOf(ctx.list, 1);
-            assert.equal(ctx.list[0].firstName, 'Dave');
-            assert.equal(ctx.list[0].lastName, 'Bassett');
-            assert.isTrue(ctx.list[0].isApplicant);
+            expect(ctx.list).to.deep.equal([{
+                'firstName': 'Dave',
+                'lastName': 'Bassett',
+                'isApplying': true,
+                'isApplicant': true
+            }]);
+        });
+
+        it('test only the executors list remains the same when executors number is not reduced', () => {
+            ctx.executorsNumber = 3;
+            ctx = ExecsNumber.createExecutorList(ctx, formdata);
+            assert.lengthOf(ctx.list, 3);
+            expect(ctx.list).to.deep.equal([
+                {
+                    'firstName': 'Dave',
+                    'lastName': 'Bassett',
+                    'isApplying': true,
+                    'isApplicant': true
+                }, {
+                    fullName: 'Ed Brown'
+                }, {
+                    fullName: 'Dave Miller'
+                }
+            ]);
+        });
+
+        it('test only the executors list remains the same when executors number is increased', () => {
+            ctx.executorsNumber = 5;
+            ctx = ExecsNumber.createExecutorList(ctx, formdata);
+            assert.lengthOf(ctx.list, 3);
+            expect(ctx.list).to.deep.equal([
+                {
+                    'firstName': 'Dave',
+                    'lastName': 'Bassett',
+                    'isApplying': true,
+                    'isApplicant': true
+                }, {
+                    fullName: 'Ed Brown'
+                }, {
+                    fullName: 'Dave Miller'
+                }
+            ]);
         });
     });
 });

--- a/test/unit/testExecutorsNumber.js
+++ b/test/unit/testExecutorsNumber.js
@@ -1,0 +1,39 @@
+'use strict';
+const initSteps = require('app/core/initSteps');
+const assert = require('chai').assert;
+
+describe('Executors-Applying', function () {
+    const ExecsNumber = initSteps([`${__dirname}/../../app/steps/action/`, `${__dirname}/../../app/steps/ui`]).ExecutorsNumber;
+
+    describe('createExecutorList', () => {
+
+        it('test only the main applicant is in the executors list when executors number is reduced', () => {
+            const ctx = {
+                executorsNumber: 2
+            };
+            const formdata = {
+                'applicant': {
+                    'firstName': 'Dave',
+                    'lastName': 'Bassett'
+                },
+                list: [
+                    {
+                        'firstName': 'Dave',
+                        'lastName': 'Bassett',
+                        'isApplying': 'Yes',
+                        'isApplicant': true
+                    }, {
+                        fullName: 'Ed Brown'
+                    }, {
+                        fullName: 'Dave Miller'
+                    }
+                ],
+            };
+            ExecsNumber.createExecutorList(ctx, formdata);
+            assert.lengthOf(ctx.list, 1);
+            assert.equal(ctx.list[0].firstName, 'Dave');
+            assert.equal(ctx.list[0].lastName, 'Bassett');
+            assert.isTrue(ctx.list[0].isApplicant);
+        });
+    });
+});

--- a/test/unit/testExecutorsWrapper.js
+++ b/test/unit/testExecutorsWrapper.js
@@ -373,4 +373,38 @@ describe('Executors.js', () => {
             });
         });
     });
+
+    describe('mainApplicant()', () => {
+        beforeEach(() => {
+            data = {
+                list: [
+                    {firstName: 'james', lastName: 'miller', isApplying: true, isApplicant: true},
+                    {fullname: 'ed brown', isApplying: true}
+                ]
+            };
+        });
+        it('should return the main applicant', (done) => {
+            const executorsWrapper = new ExecutorsWrapper(data);
+            expect(executorsWrapper.mainApplicant()).to.deep.equal([
+                {firstName: 'james', lastName: 'miller', isApplying: true, isApplicant: true}
+            ]);
+            done();
+        });
+
+        describe('should return an empty list', () => {
+            it('when none of the executors is the main applicant', (done) => {
+                data.list[0].isApplicant = false;
+                const executorsWrapper = new ExecutorsWrapper(data);
+                expect(executorsWrapper.mainApplicant()).to.deep.equal([]);
+                done();
+            });
+
+            it('when there is no executor data', (done) => {
+                const data = {};
+                const executorsWrapper = new ExecutorsWrapper(data);
+                expect(executorsWrapper.executorsWithAnotherName()).to.deep.equal([]);
+                done();
+            });
+        });
+    });
 });

--- a/test/unit/testExecutorsWrapper.js
+++ b/test/unit/testExecutorsWrapper.js
@@ -1,4 +1,5 @@
 // eslint-disable-line max-lines
+'use strict';
 
 const ExecutorsWrapper = require('app/wrappers/Executors');
 const chai = require('chai');
@@ -10,7 +11,7 @@ describe('Executors.js', () => {
         data = {
             list: [
                 {firstName: 'james', lastName: 'miller', isApplying: true, isApplicant: true},
-                {fullname: 'ed brown', isApplying: true}
+                {fullName: 'ed brown', isApplying: true}
             ]
         };
     });
@@ -66,7 +67,7 @@ describe('Executors.js', () => {
             data = {
                 list: [
                     {firstName: 'james', lastName: 'miller', isApplying: true, isApplicant: true},
-                    {fullname: 'ed brown', isApplying: false, notApplyingKey: 'optionPowerReserved'}
+                    {fullName: 'ed brown', isApplying: false, notApplyingKey: 'optionPowerReserved'}
                 ]
             };
         });
@@ -112,7 +113,7 @@ describe('Executors.js', () => {
             data = {
                 list: [
                     {firstName: 'james', lastName: 'miller', isApplying: true, isApplicant: true},
-                    {fullname: 'ed brown', isApplying: false, notApplyingKey: 'optionRenunciated'}
+                    {fullName: 'ed brown', isApplying: false, notApplyingKey: 'optionRenunciated'}
                 ]
             };
         });
@@ -138,8 +139,8 @@ describe('Executors.js', () => {
             data = {
                 list: [
                     {firstName: 'james', lastName: 'miller', isApplying: true, isApplicant: true},
-                    {fullname: 'ed brown', isApplying: false, notApplyingKey: 'optionPowerReserved'},
-                    {fullname: 'jake smith', isApplying: false, notApplyingKey: 'optionRenunciated'}
+                    {fullName: 'ed brown', isApplying: false, notApplyingKey: 'optionPowerReserved'},
+                    {fullName: 'jake smith', isApplying: false, notApplyingKey: 'optionRenunciated'}
                 ]
             };
         });
@@ -253,7 +254,7 @@ describe('Executors.js', () => {
         beforeEach(() => {
             data = {
                 list: [
-                    {fullname: 'ed brown', isDead: true}
+                    {fullName: 'ed brown', isDead: true}
                 ]
             };
         });
@@ -276,7 +277,7 @@ describe('Executors.js', () => {
         beforeEach(() => {
             data = {
                 list: [
-                    {fullname: 'James Miller', hasOtherName: true}
+                    {fullName: 'James Miller', hasOtherName: true}
                 ]
             };
         });
@@ -309,8 +310,8 @@ describe('Executors.js', () => {
             data = {
                 list: [
                     {firstName: 'james', lastName: 'miller', isApplying: true, isApplicant: true},
-                    {fullname: 'ed brown', isApplying: true},
-                    {fullname: 'jake smith', isDead: true}
+                    {fullName: 'ed brown', isApplying: true},
+                    {fullName: 'jake smith', isDead: true}
                 ]
             };
         });
@@ -343,8 +344,8 @@ describe('Executors.js', () => {
             data = {
                 list: [
                     {firstName: 'james', lastName: 'miller', isApplying: true, isApplicant: true},
-                    {fullname: 'ed brown', hasOtherName: true},
-                    {fullname: 'jake smith', has: true}
+                    {fullName: 'ed brown', hasOtherName: true},
+                    {fullName: 'jake smith', has: true}
                 ]
             };
         });
@@ -352,7 +353,7 @@ describe('Executors.js', () => {
         it('should return a list of executors with another name', (done) => {
             const executorsWrapper = new ExecutorsWrapper(data);
             expect(executorsWrapper.executorsWithAnotherName()).to.deep.equal([
-                {fullname: 'ed brown', hasOtherName: true}
+                {fullName: 'ed brown', hasOtherName: true}
             ]);
             done();
         });
@@ -379,7 +380,7 @@ describe('Executors.js', () => {
             data = {
                 list: [
                     {firstName: 'james', lastName: 'miller', isApplying: true, isApplicant: true},
-                    {fullname: 'ed brown', isApplying: true}
+                    {fullName: 'ed brown', isApplying: true}
                 ]
             };
         });

--- a/test/unit/testFormatName.js
+++ b/test/unit/testFormatName.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const FormatName = require('app/utils/FormatName');
 const chai = require('chai');
 const expect = chai.expect;

--- a/test/unit/testFormatUrl.js
+++ b/test/unit/testFormatUrl.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const expect = require('chai').expect;
 const FormatUrl = require('app/utils/FormatUrl');
 

--- a/test/unit/testHealthcheck.js
+++ b/test/unit/testHealthcheck.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const {expect} = require('chai');
 const app = require('app');
 const request = require('supertest');

--- a/test/unit/testInitialsFilter.js
+++ b/test/unit/testInitialsFilter.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const initialsFilter = require('app/components/initialsFilter');
 const assert = require('chai').assert;
 

--- a/test/unit/testOptionGetRunner.js
+++ b/test/unit/testOptionGetRunner.js
@@ -1,8 +1,10 @@
-const OptionGetRunner = require('app/core/runners/OptionGetRunner'),
-      sinon = require('sinon'),
-      chai = require('chai'),
-      expect = chai.expect,
-      sinonChai = require('sinon-chai');
+'use strict';
+
+const OptionGetRunner = require('app/core/runners/OptionGetRunner');
+const sinon = require('sinon');
+const chai = require('chai');
+const expect = chai.expect;
+const sinonChai = require('sinon-chai');
 
 chai.use(sinonChai);
 

--- a/test/unit/testPaymentData.js
+++ b/test/unit/testPaymentData.js
@@ -1,6 +1,8 @@
-const paymentData = require('app/components/payment-data'),
-    assert = require('chai').assert,
-    config = require('app/config');
+'use strict';
+
+const paymentData = require('app/components/payment-data');
+const assert = require('chai').assert;
+const config = require('app/config');
 
 describe('PaymentData', function () {
 

--- a/test/unit/testPaymentStatus.js
+++ b/test/unit/testPaymentStatus.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const initSteps = require('app/core/initSteps');
 const assert = require('chai').assert;
 const config = require('test/config');

--- a/test/unit/testRegistryWrapper.js
+++ b/test/unit/testRegistryWrapper.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const RegistryWrapper = require('app/wrappers/Registry');
 const chai = require('chai');
 const expect = chai.expect;

--- a/test/unit/testSecurity.js
+++ b/test/unit/testSecurity.js
@@ -1,10 +1,10 @@
 'use strict';
-const proxyquire = require('proxyquire'),
-    chai = require('chai'),
-    sinon = require('sinon'),
-    when = require('when'),
-    expect = chai.expect,
-    sinonChai = require('sinon-chai');
+const proxyquire = require('proxyquire');
+const chai = require('chai');
+const sinon = require('sinon');
+const when = require('when');
+const expect = chai.expect;
+const sinonChai = require('sinon-chai');
 
 const services = require('app/components/services');
 

--- a/test/unit/testSoftStops.js
+++ b/test/unit/testSoftStops.js
@@ -1,5 +1,6 @@
-const initSteps = require('app/core/initSteps'),
-      assert = require('chai').assert;
+'use strict';
+const initSteps = require('app/core/initSteps');
+const assert = require('chai').assert;
 
 describe('Soft Stops', function () {
     const steps = initSteps([__dirname + '/../../app/steps/action/', __dirname + '/../../app/steps/ui/']);

--- a/test/unit/testStringifyNumberBelow21.js
+++ b/test/unit/testStringifyNumberBelow21.js
@@ -1,5 +1,6 @@
-const utils = require('app/components/utils'),
-    assert = require('chai').assert;
+'use strict';
+const utils = require('app/components/utils');
+const assert = require('chai').assert;
 
     describe('Test stringifyNumberBelow21', function () {
 

--- a/test/unit/testSubmitData.js
+++ b/test/unit/testSubmitData.js
@@ -1,3 +1,4 @@
+'use strict';
 const submitData = require('app/components/submit-data');
 const formData = require('test/data/complete-form-multipleapplicants');
 const initSteps = require('app/core/initSteps');

--- a/test/unit/testTasklist.js
+++ b/test/unit/testTasklist.js
@@ -1,7 +1,8 @@
-const initSteps = require('app/core/initSteps'),
-  journeyMap = require('app/core/journeyMap'),
-  assert = require('chai').assert,
-  completedForm = require('test/data/complete-form').formdata;
+'use strict';
+const initSteps = require('app/core/initSteps');
+const journeyMap = require('app/core/journeyMap');
+const assert = require('chai').assert;
+const completedForm = require('test/data/complete-form').formdata;
 
 describe('Tasklist', function () {
 

--- a/test/unit/testWillDate.js
+++ b/test/unit/testWillDate.js
@@ -1,6 +1,7 @@
-const initSteps = require('app/core/initSteps'),
-    assert = require('chai').assert,
-    {set} = require('lodash');
+'use strict';
+const initSteps = require('app/core/initSteps');
+const assert = require('chai').assert;
+const {set} = require('lodash');
 
 describe('WillDate', function () {
 

--- a/test/unit/testWillWrapper.js
+++ b/test/unit/testWillWrapper.js
@@ -1,3 +1,4 @@
+'use strict';
 const WillWrapper = require('app/wrappers/Will');
 const commonContent = require('app/resources/en/translation/common');
 const chai = require('chai');


### PR DESCRIPTION
	  - checking all agreed uses formdata and the values of isApplying and the most recent inviteID
	  - if an executor is no longer dealing with the estate the isApplying flag is removed
	  - the logic for filtering the applying executors now takes place in the backend business service

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PRO-2134


### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
