### PR TITLE
PRO-3165: Fix to handle S2S failures prior to making a payment.

### DIFF
--- a/app/steps/ui/payment/breakdown/index.js
+++ b/app/steps/ui/payment/breakdown/index.js
@@ -68,6 +68,8 @@ class PaymentBreakdown extends Step {
 
                     if (serviceAuthResult.name === 'Error') {
                         const keyword = 'failure';
+                        formdata.creatingPayment = null;
+                        formdata.paymentPending = null;
                         errors.push(FieldError('authorisation', keyword, this.resourcePath, ctx));
                         return [ctx, errors];
                     }

--- a/test/data/complete-form-undeclared.json
+++ b/test/data/complete-form-undeclared.json
@@ -67,7 +67,8 @@
     },
     "payment": {
       "paymentDue": "true",
-      "total": 5001
+      "total": 5001,
+      "paymentId": 1
     },
     "paymentPending": "true"
   }

--- a/test/service-stubs/payment.js
+++ b/test/service-stubs/payment.js
@@ -8,6 +8,7 @@ const express = require('express'),
     bodyParser = require('body-parser');
 let lastId;
 
+const UNDEFINED_PAY_ID = 'undefined';
 const FAILURE_NAME = 'Break';
 const FAILURE_PAY_ID = '999';
 const PAYMENT_STUB_PORT = 8383;
@@ -39,16 +40,20 @@ router.post('/users/:userId/payments', function (req, res) {
 
 router.get('/users/:userId/payments/:paymentId', function (req, res) {
     const data = require('test/data/payments/find.json');
-    if (req.params.paymentId === FAILURE_PAY_ID) {
+    if (req.params.paymentId === UNDEFINED_PAY_ID) {
+        res.status(500);
+        console.log(500);
+    } else if (req.params.paymentId === FAILURE_PAY_ID) {
         data.state.status = 'failed';
         res.status(200);
         res.send(data);
+        console.log(data);
     } else {
         res.status(200);
         res.send(data);
+        console.log(200);
+        console.log(data);
     }
-    console.log(200);
-    console.log(data);
     delete require.cache[require.resolve('test/data/payments/find.json')];
 });
 

--- a/test/unit/testPaymentBreakdown.js
+++ b/test/unit/testPaymentBreakdown.js
@@ -2,10 +2,25 @@
 
 const initSteps = require('app/core/initSteps');
 const assert = require('chai').assert;
+const config = require('test/config');
 const co = require('co');
 
 describe('PaymentBreakdown', () => {
     const steps = initSteps([`${__dirname}/../../app/steps/action/`, `${__dirname}/../../app/steps/ui`]);
+    let s2sStub, payStub;
+
+    before(() => {
+        config.s2sStubErrorSequence = '01';
+        s2sStub = require('test/service-stubs/idam');
+        payStub = require('test/service-stubs/payment');
+    });
+
+    after(() => {
+        s2sStub.close();
+        payStub.close();
+        delete require.cache[require.resolve('test/service-stubs/idam')];
+        delete require.cache[require.resolve('test/service-stubs/payment')];
+    });
 
     describe('handleGet', () => {
         it('cleans up context', () => {
@@ -54,20 +69,44 @@ describe('PaymentBreakdown', () => {
 
         it('sets paymentPending to true if ctx.total > 0', (done) => {
             const PaymentBreakdown = steps.PaymentBreakdown;
+            const hostname = 'localhost';
             let ctx = {total: 215};
             let errors = [];
             const formdata = {};
             const session = {};
+
             /*eslint no-empty-function: 0*/
             session.save = () => {};
             co(function* () {
-                [ctx, errors] = yield PaymentBreakdown.handlePost(ctx, errors, formdata, session);
+                [ctx, errors] = yield PaymentBreakdown.handlePost(ctx, errors, formdata, session, hostname);
                 assert.deepEqual(formdata.paymentPending, 'true');
                 done();
             })
-                .catch((err) => {
-                    done(err);
-                });
+            .catch((err) => {
+                done(err);
+            });
+        });
+
+        it('sets paymentPending and createPayment to undefined if authorise fails before createPayment', (done) => {
+            const PaymentBreakdown = steps.PaymentBreakdown;
+            const hostname = 'localhost';
+            let ctx = {total: 215};
+            let errors = [];
+            const formdata = {};
+            const session = {};
+
+            /*eslint no-empty-function: 0*/
+            session.save = () => {};
+            co(function* () {
+                [ctx, errors] = yield PaymentBreakdown.handlePost(ctx, errors, formdata, session, hostname);
+                assert.exists(errors[0].msg, 'error message not found');
+                assert.equal(formdata.paymentPending, null);
+                assert.equal(formdata.creatingPayment, null);
+                done();
+            })
+            .catch((err) => {
+                done(err);
+            });
         });
     });
 

--- a/test/unit/testPaymentStatus.js
+++ b/test/unit/testPaymentStatus.js
@@ -6,12 +6,20 @@ const co = require('co');
 describe('PaymentStatus', function () {
 
     const steps = initSteps([__dirname + '/../../app/steps/ui/']);
+    let s2sStub;
+
+    before(() => {
+        config.s2sStubErrorSequence = '1';
+        s2sStub = require('test/service-stubs/idam');
+    });
+
+    after(() => {
+        s2sStub.close();
+        delete require.cache[require.resolve('test/service-stubs/idam')];
+    });
 
     describe('runnerOptions', function () {
         it('Should set paymentPending to unknown if an authorise failure', function (done) {
-
-            config.s2sStubErrorSequence = '1';
-            require('test/service-stubs/idam');
 
             const PaymentStatus = steps.PaymentStatus;
             const ctx = {total: 1};

--- a/test/unit/testPaymentStatus.js
+++ b/test/unit/testPaymentStatus.js
@@ -1,68 +1,106 @@
+'use strict';
+
 const initSteps = require('app/core/initSteps');
 const assert = require('chai').assert;
 const co = require('co');
 const services = require('app/components/services');
 const sinon = require('sinon');
 
-describe('PaymentStatus', function () {
-
+describe('PaymentStatus', () => {
     const steps = initSteps([__dirname + '/../../app/steps/ui/']);
-    let s2sAuthoriseStub;
 
-    beforeEach(function () {
-        s2sAuthoriseStub = sinon.stub(services, 'authorise');
-    });
-
-    afterEach(function () {
-        s2sAuthoriseStub.restore();
-    });
-
-    describe('runnerOptions', function () {
-        it('Should set paymentPending to unknown if an authorise failure', function (done) {
-            s2sAuthoriseStub.returns(Promise.resolve({name: 'Error'}));
+    describe('runnerOptions', () => {
+        it('should set paymentPending to unknown if there is an authorise failure', (done) => {
+            const authoriseStub = sinon
+                .stub(services, 'authorise')
+                .returns(Promise.resolve({name: 'Error'}));
             const PaymentStatus = steps.PaymentStatus;
             const ctx = {total: 1};
             const formdata = {paymentPending: 'true'};
-            let options = {};
             co(function* () {
-                options = yield PaymentStatus.runnerOptions(ctx, formdata);
-                assert.equal(options.redirect, true);
-                assert.equal(options.url, '/payment-breakdown?status=failure');
-                assert.equal(formdata.paymentPending, 'unknown');
+                const options = yield PaymentStatus.runnerOptions(ctx, formdata);
+                assert.deepEqual(options, {
+                    redirect: true,
+                    url: '/payment-breakdown?status=failure'
+                });
+                assert.deepEqual(formdata, {
+                    paymentPending: 'unknown'
+                });
+                authoriseStub.restore();
                 done();
-            })
-                .catch((err) => {
+            }).catch(err => {
                 done(err);
             });
         });
     });
 
-    describe('sendApplication', function () {
-        it('Should create an error if the sendApplication fails', function (done) {
-            s2sAuthoriseStub.returns(Promise.resolve({name: 'Success'}));
-            const PaymentStatus = steps.PaymentStatus;
-            const ctx = {};
-            const formdata = {};
-            co(function * () {
-                const errors = yield PaymentStatus.sendApplication(ctx, formdata);
-                assert.exists(errors[0].msg, 'error message not found');
-                done();
-            }).catch((err) => {
-                done(err);
+    describe('sendApplication', () => {
+        let submitApplicationStub;
+
+        beforeEach(() => {
+            submitApplicationStub = sinon.stub(services, 'submitApplication');
+        });
+
+        afterEach(() => {
+            submitApplicationStub.restore();
+        });
+
+        describe('should return an error', () => {
+            it('if submitApplication returns "Error"', (done) => {
+                submitApplicationStub.returns(Promise.resolve({name: 'Error'}));
+                const PaymentStatus = steps.PaymentStatus;
+                const ctx = {};
+                const formdata = {};
+                co(function * () {
+                    const errors = yield PaymentStatus.sendApplication(ctx, formdata);
+                    assert.deepEqual(errors, [{
+                        param: 'submit',
+                        msg: {
+                            summary: 'We could not submit your application. Your data has been saved, please try again later.',
+                            message: 'payment.status.errors.submit.failure.message'
+                        }
+                    }]);
+                    done();
+                }).catch(err => {
+                    done(err);
+                });
+            });
+
+            it('if submitApplication returns "DUPLICATE_SUBMISSION"', (done) => {
+                submitApplicationStub.returns(Promise.resolve('DUPLICATE_SUBMISSION'));
+                const PaymentStatus = steps.PaymentStatus;
+                const ctx = {};
+                const formdata = {};
+                co(function * () {
+                    const errors = yield PaymentStatus.sendApplication(ctx, formdata);
+                    assert.deepEqual(errors, [{
+                        param: 'submit',
+                        msg: {
+                            summary: 'Your application has been submitted, please return to the tasklist to continue',
+                            message: 'payment.status.errors.submit.duplicate.message'
+                        }
+                    }]);
+                    done();
+                }).catch(err => {
+                    done(err);
+                });
             });
         });
 
-        it('Should not create an error if sendApplication succeeds', function (done) {
-            s2sAuthoriseStub.returns(Promise.resolve({name: 'Success'}));
-            require('test/service-stubs/submit');
+        it('should not return an error if submitApplication returns successfully', (done) => {
+            submitApplicationStub.returns(Promise.resolve({name: 'Success'}));
+            const saveFormDataStub = sinon
+                .stub(services, 'saveFormData')
+                .returns(Promise.resolve({name: 'Success'}));
             const PaymentStatus = steps.PaymentStatus;
             const ctx = {};
             const formdata = {};
             co(function * () {
                 const errors = yield PaymentStatus.sendApplication(ctx, formdata);
-                assert.notExists(errors);
+                assert.isUndefined(errors);
+                saveFormDataStub.restore();
                 done();
-            }).catch((err) => {
+            }).catch(err => {
                 done(err);
             });
         });


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PRO-3165

### Change description ###
I've cleared the paymentPending and creatingPayment flags (set to null) if there is an authorise failure prior to the createPayment call. This change is required because authorise failures cause the application to get stuck and the user ends up in an endless loop. 

In addition to the flags being cleared, I've also introduced a new unit test. The payment stub was updated to handle undefined paymentId's and send back a HTTP 500 error as per the real service. Because of this I had to update the component test data to include a paymentId which before it had ignored and the stub just returned a successful response.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
