### PR TITLE
PRO-3065: Remove Start Page from Idam protected pages

### DIFF
--- a/app.js
+++ b/app.js
@@ -176,7 +176,7 @@ exports.init = function() {
     app.use('/health', healthcheck);
 
     if (useIDAM === 'true') {
-        app.use(/\/((?!error)(?!sign-in)(?!pin-resend)(?!pin-sent)(?!co-applicant-*)(?!pin)(?!inviteIdList).)*/, security.protect(config.services.idam.roles));
+        app.use(/\/((?!error)(?!sign-in)(?!pin-resend)(?!pin-sent)(?!co-applicant-*)(?!pin)(?!inviteIdList)(?!start-page).)*/, security.protect(config.services.idam.roles));
         app.use('/', routes);
     } else {
         app.use('/', (req, res, next) => {

--- a/app.js
+++ b/app.js
@@ -162,7 +162,7 @@ exports.init = function() {
         res.locals.serviceName = commonContent.serviceName;
         res.locals.cookieText = commonContent.cookieText;
 
-        res.locals.releaseVersion = 'v' + releaseVersion;
+        res.locals.releaseVersion = `v${releaseVersion}`;
         next();
     });
 
@@ -176,7 +176,8 @@ exports.init = function() {
     app.use('/health', healthcheck);
 
     if (useIDAM === 'true') {
-        app.use(/\/((?!error)(?!sign-in)(?!pin-resend)(?!pin-sent)(?!co-applicant-*)(?!pin)(?!inviteIdList)(?!start-page).)*/, security.protect(config.services.idam.roles));
+        const idamPages = new RegExp(`/((?!${config.nonIdamPages.join('|')}).)*`);
+        app.use(idamPages, security.protect(config.services.idam.roles));
         app.use('/', routes);
     } else {
         app.use('/', (req, res, next) => {
@@ -185,7 +186,7 @@ exports.init = function() {
             }
             req.session.regId = req.query.id || req.session.regId || req.sessionID;
             req.authToken = config.services.payment.authorization;
-            req.userId= config.services.payment.userId;
+            req.userId = config.services.payment.userId;
             next();
         }, routes);
     }

--- a/app/components/security.js
+++ b/app/components/security.js
@@ -1,15 +1,15 @@
 'use strict';
 
 const FormatUrl = require('app/utils/FormatUrl');
-const config = require('../config'),
-    services = require('app/components/services'),
-    logger = require('app/components/logger')('Init'),
-    URL = require('url'),
-    UUID = require('uuid/v4');
+const config = require('../config');
+const services = require('app/components/services');
+const logger = require('app/components/logger')('Init');
+const URL = require('url');
+const UUID = require('uuid/v4');
 
-const SECURITY_COOKIE = '__auth-token-' + config.payloadVersion,
-    REDIRECT_COOKIE = '__redirect',
-    ACCESS_TOKEN_OAUTH2 = 'access_token';
+const SECURITY_COOKIE = '__auth-token-' + config.payloadVersion;
+const REDIRECT_COOKIE = '__redirect';
+const ACCESS_TOKEN_OAUTH2 = 'access_token';
 
 module.exports = class Security {
 

--- a/app/config.js
+++ b/app/config.js
@@ -125,7 +125,7 @@ module.exports = {
     whitelistedPagesAfterDeclaration: ['/tasklist', '/executors-invites-sent', '/copies-uk', '/assets-overseas', '/copies-overseas', '/copies-summary', '/payment-breakdown', '/payment-breakdown?status=failure', '/payment-status', '/documents', '/thankyou'],
     hardStopParams: ['will.left', 'will.original', 'iht.completed', 'applicant.executor'],
     nonCachedPages: ['summary', 'tasklist'],
-    nonIdamPages: ['error', 'sign-in', 'pin-resend', 'pin-sent', 'co-applicant-*', 'pin', 'inviteIdList', 'start-page'],
+    nonIdamPages: ['error', 'sign-in', 'pin-resend', 'pin-sent', 'co-applicant-*', 'pin', 'inviteIdList', 'start-page', 'sign-out'],
     endpoints: {
         health: '/health',
         info: '/info'

--- a/app/config.js
+++ b/app/config.js
@@ -125,6 +125,7 @@ module.exports = {
     whitelistedPagesAfterDeclaration: ['/tasklist', '/executors-invites-sent', '/copies-uk', '/assets-overseas', '/copies-overseas', '/copies-summary', '/payment-breakdown', '/payment-breakdown?status=failure', '/payment-status', '/documents', '/thankyou'],
     hardStopParams: ['will.left', 'will.original', 'iht.completed', 'applicant.executor'],
     nonCachedPages: ['summary', 'tasklist'],
+    nonIdamPages: ['error', 'sign-in', 'pin-resend', 'pin-sent', 'co-applicant-*', 'pin', 'inviteIdList', 'start-page'],
     endpoints: {
         health: '/health',
         info: '/info'

--- a/app/routes.js
+++ b/app/routes.js
@@ -32,12 +32,11 @@ router.get('/', (req, res) => {
             if (result.name === 'Error') {
                 req.log.debug('Failed to load user data');
                 req.log.info({tags: 'Analytics'}, 'Application Started');
-                res.redirect('start-page');
             } else {
                 req.log.debug('Successfully loaded user data');
                 req.session.form = result.formdata;
-                res.redirect('tasklist');
             }
+            res.redirect('tasklist');
         });
 });
 

--- a/test/component/testStartPage.js
+++ b/test/component/testStartPage.js
@@ -1,19 +1,19 @@
-const TestWrapper = require('test/util/TestWrapper'),
-    TaskList = require('app/steps/ui/tasklist/index');
+const TestWrapper = require('test/util/TestWrapper');
+const TaskList = require('app/steps/ui/tasklist/index');
+const {expect} = require('chai');
 
 describe('start-page', () => {
     let testWrapper;
     const expectedNextUrlForTaskList = TaskList.getUrl();
 
-    beforeEach(() => {
-        testWrapper = new TestWrapper('StartPage');
-    });
-
-    afterEach(() => {
-        testWrapper.destroy();
-    });
-
     describe('Verify Content, Errors and Redirection', () => {
+        beforeEach(() => {
+            testWrapper = new TestWrapper('StartPage');
+        });
+
+        afterEach(() => {
+            testWrapper.destroy();
+        });
 
         it('test right content loaded on the page', (done) => {
             const excludeKeys = [];
@@ -26,4 +26,23 @@ describe('start-page', () => {
         });
 
     });
+
+    it('test page renders without being redirected to idam', (done) => {
+        const request = require('supertest');
+        const server = new (require('app').init)();
+        const agent = request.agent(server.app);
+        agent.get('/start-page')
+            .expect('Content-type', /html/)
+            .expect(200)
+            .end((err, res) => {
+                server.http.close();
+                if (err) {
+                    done(err);
+                } else {
+                    const text = res.text.toLowerCase();
+                    expect(text).to.contain('use this service to apply for probate');
+                    done();
+                }
+            });
+    }).timeout(5000);
 });

--- a/test/component/testStartPage.js
+++ b/test/component/testStartPage.js
@@ -1,19 +1,19 @@
 const TestWrapper = require('test/util/TestWrapper');
 const TaskList = require('app/steps/ui/tasklist/index');
-const {expect} = require('chai');
 
 describe('start-page', () => {
     let testWrapper;
     const expectedNextUrlForTaskList = TaskList.getUrl();
 
-    describe('Verify Content, Errors and Redirection', () => {
-        beforeEach(() => {
-            testWrapper = new TestWrapper('StartPage');
-        });
+    beforeEach(() => {
+        testWrapper = new TestWrapper('StartPage');
+    });
 
-        afterEach(() => {
-            testWrapper.destroy();
-        });
+    afterEach(() => {
+        testWrapper.destroy();
+    });
+
+    describe('Verify Content, Errors and Redirection', () => {
 
         it('test right content loaded on the page', (done) => {
             const excludeKeys = [];
@@ -26,23 +26,4 @@ describe('start-page', () => {
         });
 
     });
-
-    it('test page renders without being redirected to idam', (done) => {
-        const request = require('supertest');
-        const server = new (require('app').init)();
-        const agent = request.agent(server.app);
-        agent.get('/start-page')
-            .expect('Content-type', /html/)
-            .expect(200)
-            .end((err, res) => {
-                server.http.close();
-                if (err) {
-                    done(err);
-                } else {
-                    const text = res.text.toLowerCase();
-                    expect(text).to.contain('use this service to apply for probate');
-                    done();
-                }
-            });
-    }).timeout(5000);
 });


### PR DESCRIPTION
	  - root of the app to be tasklist
	  - new pages introduced will point at start-page, once the user clicks they will be taken to idam as the root of the app (tasklist) will still be protected by idam

This is to be tied in with PRO-3066 as part of the new journey into our probate application once we reach public beta.

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###



### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
