### PR TITLE
PRO-1699 - Save and Close

### DIFF
--- a/app/steps/ui/executors/applying/template.html
+++ b/app/steps/ui/executors/applying/template.html
@@ -8,7 +8,7 @@
 {% endblock %}
 
 {% block form_content %}
-    
+
     <p>{{content.paragraph1 | safe}}</p>
 
     {{ unorderedList([content["applicant-rights1"], content["applicant-rights2"], content["applicant-rights3"]])}}
@@ -20,7 +20,7 @@
         legend = content.legend,
         inline = true
     )}}
-    <div class="formgroup">
+    <div class="form-group">
         <input class="button" type="submit" value="{{common.continue}}">
     </div>
 {% endblock %}


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/PRO-1699

### Change description ###

Fix missing gap between the `Save and continue` and `Save and close` buttons on the `/other-executors-applying` page

Changed the class of the wrapper around the `Save and continue` button from `.formgroup` to `.form-group`

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```