### PR TITLE
[PREVIEW] PRO-1564 - Select both an address from postcode lookup and manual address - on submit causes lookup select list to reset to "Select address"

### DIFF
--- a/app/views/widgets/addresslookup.html
+++ b/app/views/widgets/addresslookup.html
@@ -20,7 +20,7 @@
         <option value="">{{content.selectAddress}}</option>
         {% for address in fields.addresses.value %}
             {% set formattedAddress = address.formatted_address | replace("\n"," ") %}
-            <option {{"selected" if formattedAddress === fields.address.value }}>{{formattedAddress}}</option>
+            <option {{ "selected" if formattedAddress === fields.postcodeAddress.value }}>{{formattedAddress}}</option>
         {% endfor %}
     </select>
 </div>

--- a/test/component/applicant/testAddress.js
+++ b/test/component/applicant/testAddress.js
@@ -61,5 +61,27 @@ describe('applicant-address', () => {
             testWrapper.testRedirect(done, data, expectedNextUrlForExecsNumber);
         });
 
+        it('should display the selected address option if an error is caused by completing both addresses', (done) => {
+            const data = {
+                postcode: 'SW1H 9AJ',
+                postcodeAddress: 'Ministry of Justice Seventh Floor 102 Petty France London SW1H 9AJ',
+                freeTextAddress: 'Some other random address',
+                addresses: [{
+                    building_number: '102',
+                    organisation_name: 'MINISTRY OF JUSTICE',
+                    post_town: 'LONDON',
+                    postcode: 'SW1H 9AJ',
+                    sub_building_name: 'SEVENTH FLOOR',
+                    thoroughfare_name: 'PETTY FRANCE',
+                    uprn: '10033604583',
+                    formatted_address: 'Ministry of Justice\nSeventh Floor\n102 Petty France\nLondon\nSW1H 9AJ'
+                }]
+            };
+            const contentToCheck = [
+                `<option selected>${data.postcodeAddress}</option>`
+            ];
+            testWrapper.testContentAfterError(data, contentToCheck, done);
+        });
+
     });
 });

--- a/test/util/TestWrapper.js
+++ b/test/util/TestWrapper.js
@@ -82,6 +82,17 @@ module.exports = class TestWrapper {
             .catch(done);
     }
 
+    testContentAfterError(data, contentToCheck, done) {
+        this.agent.post(this.pageUrl)
+            .send(data)
+            .expect('Content-type', 'text/html; charset=utf-8')
+            .then(res => {
+                this.assertContentIsPresent(res.text, contentToCheck);
+                done();
+            })
+            .catch(done);
+    }
+
     testRedirect(done, postData, expectedNextUrl) {
         this.agent.post(this.pageUrl)
             .type('form')


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/PRO-1564

### Change description ###

- Fix address lookup so the selected address is displayed in the dropdown list if an error occurs
- Add a test method to enable content to be checked on the page if an error occurs
- Add a component test to check that the correct address is displayed in the dropdown list if an error occurs

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```