### PR TITLE
[PREVIEW] PRO-3151 - Postcode Lookup - cannot update postcode

### DIFF
--- a/app/core/steps/AddressStep.js
+++ b/app/core/steps/AddressStep.js
@@ -19,9 +19,7 @@ class AddressStep extends ValidationStep {
     handlePost(ctx, errors) {
         ctx.address = ctx.postcodeAddress || ctx.freeTextAddress;
         ctx.postcode = ctx.postcode ? ctx.postcode.toUpperCase() : ctx.postcode;
-        if (ctx.postcodeAddress) {
-            ctx.addresses = [{formatted_address: ctx.postcodeAddress}];
-        } else {
+        if (!ctx.postcodeAddress) {
             delete ctx.addresses;
         }
         delete ctx.referrer;

--- a/test/component/applicant/testAddress.js
+++ b/test/component/applicant/testAddress.js
@@ -1,5 +1,7 @@
-const TestWrapper = require('test/util/TestWrapper'),
-    ExecutorsNumber = require('app/steps/ui/executors/number/index');
+const TestWrapper = require('test/util/TestWrapper');
+const ExecutorsNumber = require('app/steps/ui/executors/number/index');
+const testAddressData = require('test/data/find-address');
+const formatAddress = address => address.replace(/\n/g, ' ');
 
 describe('applicant-address', () => {
     let testWrapper;
@@ -83,5 +85,22 @@ describe('applicant-address', () => {
             testWrapper.testContentAfterError(data, contentToCheck, done);
         });
 
+        it('test the address dropdown box displays all addresses when the user returns to the page', (done) => {
+            const sessionData = {
+                postcode: testAddressData[1].postcode,
+                postcodeAddress: formatAddress(testAddressData[1].formatted_address),
+                addresses: testAddressData
+            };
+            testWrapper.agent
+                .post(testWrapper.pageUrl)
+                .send(sessionData)
+                .end(() => {
+                    const contentToCheck = testAddressData.map(address => {
+                        const formattedAddress = formatAddress(address.formatted_address);
+                        return `<option ${formattedAddress === sessionData.postcodeAddress ? 'selected' : ''}>${formattedAddress}</option>`;
+                    });
+                    testWrapper.testDataPlayback(done, contentToCheck);
+                });
+        });
     });
 });

--- a/test/component/applicant/testAddress.js
+++ b/test/component/applicant/testAddress.js
@@ -28,7 +28,7 @@ describe('applicant-address', () => {
             testWrapper.testErrors(done, data, 'required', ['postcodeLookup']);
         });
 
-        it('test validation when address search is successful, but no address is selected/entered', (done) => {
+        it('test validation when address search is successful, but no address is selected or entered', (done) => {
             const data = {addressFound: 'true'};
 
             testWrapper.testErrors(done, data, 'oneOf', ['crossField']);

--- a/test/data/find-address.json
+++ b/test/data/find-address.json
@@ -7,4 +7,22 @@
   "thoroughfare_name": "PETTY FRANCE",
   "uprn": "10033604583",
   "formatted_address": "Ministry of Justice\nSeventh Floor\n102 Petty France\nLondon\nSW1H 9AJ"
+}, {
+  "building_number": "103",
+  "organisation_name": "MINISTRY OF JUSTICE",
+  "post_town": "LONDON",
+  "postcode": "SW1H 9AJ",
+  "sub_building_name": "SEVENTH FLOOR",
+  "thoroughfare_name": "PETTY FRANCE",
+  "uprn": "10033604583",
+  "formatted_address": "Ministry of Justice\nSeventh Floor\n103 Petty France\nLondon\nSW1H 9AJ"
+}, {
+  "building_number": "104",
+  "organisation_name": "MINISTRY OF JUSTICE",
+  "post_town": "LONDON",
+  "postcode": "SW1H 9AJ",
+  "sub_building_name": "SEVENTH FLOOR",
+  "thoroughfare_name": "PETTY FRANCE",
+  "uprn": "10033604583",
+  "formatted_address": "Ministry of Justice\nSeventh Floor\n104 Petty France\nLondon\nSW1H 9AJ"
 }]

--- a/test/unit/testAddressStep.js
+++ b/test/unit/testAddressStep.js
@@ -1,0 +1,102 @@
+'use strict';
+
+const AddressStep = require('app/core/steps/AddressStep');
+const chai = require('chai');
+const expect = chai.expect;
+
+describe('AddressStep', () => {
+    let steps;
+    let section;
+    let templatePath;
+    let i18next;
+    let schema;
+    let ctxToTest;
+    let error;
+
+    beforeEach(() => {
+        steps = {};
+        section = 'executors';
+        templatePath = 'addressLookup';
+        i18next = {};
+        schema = {
+            '$schema': 'http://json-schema.org/draft-04/schema#',
+            properties: {}
+        };
+        ctxToTest = {};
+        error = {
+            field: 'address',
+            message: 'Please enter an address'
+        };
+    });
+
+    describe('handleGet()', () => {
+        it('should return ctx when there are no errors', (done) => {
+            const addressStep = new AddressStep(steps, section, templatePath, i18next, schema);
+            const ctx = addressStep.handleGet(ctxToTest, null);
+            expect(ctx).to.deep.equal([ctxToTest]);
+            done();
+        });
+
+        it('should return ctx and errors when there are errors', (done) => {
+            const formdata = {
+                executors: {errors: error}
+            };
+            ctxToTest.errors = error;
+            const addressStep = new AddressStep(steps, section, templatePath, i18next, schema);
+            const ctx = addressStep.handleGet(ctxToTest, formdata);
+            expect(ctx).to.deep.equal([ctxToTest, error]);
+            expect(formdata).to.deep.equal({
+                executors: {}
+            });
+            done();
+        });
+    });
+
+    describe('handlePost()', () => {
+        describe('should return ctx and errors', () => {
+            it('when postcodeAddress exists', (done) => {
+                ctxToTest = {
+                    postcodeAddress: '1 Red Road, London, LL1 1LL',
+                    referrer: 'executorApplicant',
+                    postcode: 'll1 1ll',
+                    addresses: [
+                        {address: '1 Red Road, London, LL1 1LL'},
+                        {address: '2 Green Road, London, LL2 2LL'}
+                    ]
+                };
+                const addressStep = new AddressStep(steps, section, templatePath, i18next, schema);
+                const ctx = addressStep.handlePost(ctxToTest, null);
+                expect(ctx).to.deep.equal([{
+                    address: '1 Red Road, London, LL1 1LL',
+                    postcode: 'LL1 1LL',
+                    postcodeAddress: '1 Red Road, London, LL1 1LL',
+                    addresses: [
+                        {address: '1 Red Road, London, LL1 1LL'},
+                        {address: '2 Green Road, London, LL2 2LL'}
+                    ]
+                }, null]);
+                done();
+            });
+
+            it('when freeTextAddress exists', (done) => {
+                ctxToTest = {
+                    freeTextAddress: '1 Red Road, London, LL1 1LL',
+                    referrer: 'executorApplicant',
+                    postcode: 'll1 1ll',
+                    addresses: [
+                        {address: '1 Red Road, London, LL1 1LL'},
+                        {address: '2 Green Road, London, LL2 2LL'}
+                    ]
+                };
+                const addressStep = new AddressStep(steps, section, templatePath, i18next, schema);
+                const ctx = addressStep.handlePost(ctxToTest, null);
+                expect(ctx).to.deep.equal([{
+                    address: '1 Red Road, London, LL1 1LL',
+                    postcode: 'LL1 1LL',
+                    freeTextAddress: '1 Red Road, London, LL1 1LL'
+                }, null]);
+                done();
+            });
+        });
+    });
+});


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/PRO-3151

### Change description ###

- Change AddressStep so it retains all addresses found in the postcode lookup
  If the user returns to the address page after selecting an address we want all the available address to be displayed in the address dropdown box rather than just the one the user selected.

- Add a component test to check that the AddressStep retains all addresses found in the postcode lookup

- Update address test data to return 3 addresses rather than just 1


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```