### PR TITLE
[PREVIEW] Pro 3459 pin not working for international numbers

### DIFF
--- a/infrastructure/preview.tfvars
+++ b/infrastructure/preview.tfvars
@@ -39,5 +39,5 @@ probate_submit_service_url = "http://probate-submit-service-aat.service.core-com
 probate_persistence_service_url = "http://probate-persistence-service-aat.service.core-compute-aat.internal/formdata"
 
 feature_toggles_api_url = "http://rpe-feature-toggle-api-aat.service.core-compute-aat.internal"
-asp_name = "probate-aat-asp-aat-asp"
-asp_rg = "mgmt-asp-aat"
+asp_name = "probate-preview"
+asp_rg = "probate-preview"

--- a/test/contract/generatepin/testGeneratePin.js
+++ b/test/contract/generatepin/testGeneratePin.js
@@ -17,6 +17,7 @@ const VALID_PIN_CONTENT_LENGTH = '6';
 describe('Pin Creation API Tests', () => {
 
     const pinServiceUrl = FormatUrl.format(TEST_VALIDATION_SERVICE_URL, '/pin');
+    const numberMatchRE = new RegExp(/[0-9]+/);
 
     describe('Invalid number which should produce a 400 Bad Request', () => {
         it('Returns HTTP 400 status', (done) => {
@@ -67,6 +68,7 @@ describe('Pin Creation API Tests', () => {
                         logger.error(`error raised: ${err} using URL ${pinServiceUrl}`);
                     } else {
                         expect(err).to.be.equal(null);
+                        expect(res.text).to.match(numberMatchRE);
                         expect(res.header).to.have.property('content-length').eq(VALID_PIN_CONTENT_LENGTH);
                         expect(res.text).is.not.equal(null);
                     }
@@ -87,6 +89,7 @@ describe('Pin Creation API Tests', () => {
                         logger.error(`error raised: ${err} using URL ${pinServiceUrl}`);
                     } else {
                         expect(err).to.be.equal(null);
+                        expect(res.text).to.match(numberMatchRE);
                         expect(res.header).to.have.property('content-length').eq(VALID_PIN_CONTENT_LENGTH);
                         expect(res.text).is.not.equal(null);
                     }
@@ -107,6 +110,7 @@ describe('Pin Creation API Tests', () => {
                         logger.error(`error raised: ${err} using URL ${pinServiceUrl}`);
                     } else {
                         expect(err).to.be.equal(null);
+                        expect(res.text).to.match(numberMatchRE);
                         expect(res.header).to.have.property('content-length').eq(VALID_PIN_CONTENT_LENGTH);
                         expect(res.text).is.not.equal(null);
                     }

--- a/test/contract/generatepin/testGeneratePin.js
+++ b/test/contract/generatepin/testGeneratePin.js
@@ -17,7 +17,7 @@ const VALID_PIN_CONTENT_LENGTH = '6';
 describe('Pin Creation API Tests', () => {
 
     const pinServiceUrl = FormatUrl.format(TEST_VALIDATION_SERVICE_URL, '/pin');
-    const numberMatchRE = new RegExp(/[0-9]+/);
+    const numberMatchRE = new RegExp(/^[0-9]+$/);
 
     describe('Invalid number which should produce a 400 Bad Request', () => {
         it('Returns HTTP 400 status', (done) => {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PRO-3459

### Change description ###
Update to PRO-3459 to include an extra check for the test response to be an actual number. It would appear sometimes the text response from Notify is returning an error message and this ends up being passed back to the frontend application. With the check in place any messages from Notify which do not match a numerical value will be shown in the console logs.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
