### PR TITLE
[PREVIEW] Pro 3459 pin not working for international numbers

### DIFF
--- a/test/contract/generatepin/testGeneratePin.js
+++ b/test/contract/generatepin/testGeneratePin.js
@@ -12,7 +12,7 @@ const INVALID_TEST_NUMBER = '+$447701111111';
 const VALID_INTERNATIONAL_TEST_NUMBER = '+61437112945';
 const VALID_UK_WITH_PREFIX_TEST_NUMBER = '+447535538319';
 const VALID_UK_LOCAL_TEST_NUMBER = '07535538319';
-const VALID_PIN_CONTENT_LENGTH = '6';
+const VALID_PIN_CONTENT_LENGTH = 6;
 
 describe('Pin Creation API Tests', () => {
 
@@ -67,10 +67,9 @@ describe('Pin Creation API Tests', () => {
                     if (err) {
                         logger.error(`error raised: ${err} using URL ${pinServiceUrl}`);
                     } else {
-                        logger.error('RESPONSE: ' + JSON.stringify(res));
                         expect(err).to.be.equal(null);
                         expect(res.text).to.match(numberMatchRE);
-                        expect(res.header).to.have.property('content-length').eq(VALID_PIN_CONTENT_LENGTH);
+                        expect(res.text.length).to.equal(VALID_PIN_CONTENT_LENGTH);
                         expect(res.text).is.not.equal(null);
                     }
                     done();
@@ -89,10 +88,9 @@ describe('Pin Creation API Tests', () => {
                     if (err) {
                         logger.error(`error raised: ${err} using URL ${pinServiceUrl}`);
                     } else {
-                        logger.error('RESPONSE: ' + JSON.stringify(res));
                         expect(err).to.be.equal(null);
                         expect(res.text).to.match(numberMatchRE);
-                        expect(res.header).to.have.property('content-length').eq(VALID_PIN_CONTENT_LENGTH);
+                        expect(res.text.length).to.equal(VALID_PIN_CONTENT_LENGTH);
                         expect(res.text).is.not.equal(null);
                     }
                     done();
@@ -111,10 +109,9 @@ describe('Pin Creation API Tests', () => {
                     if (err) {
                         logger.error(`error raised: ${err} using URL ${pinServiceUrl}`);
                     } else {
-                        logger.error('RESPONSE: ' + JSON.stringify(res));
                         expect(err).to.be.equal(null);
                         expect(res.text).to.match(numberMatchRE);
-                        expect(res.header).to.have.property('content-length').eq(VALID_PIN_CONTENT_LENGTH);
+                        expect(res.text.length).to.equal(VALID_PIN_CONTENT_LENGTH);
                         expect(res.text).is.not.equal(null);
                     }
                     done();

--- a/test/contract/generatepin/testGeneratePin.js
+++ b/test/contract/generatepin/testGeneratePin.js
@@ -17,6 +17,7 @@ const VALID_PIN_CONTENT_LENGTH = '6';
 describe('Pin Creation API Tests', () => {
 
     const pinServiceUrl = FormatUrl.format(TEST_VALIDATION_SERVICE_URL, '/pin');
+    const numberMatchRE = new RegExp(/[0-9]+/);
 
     describe('Invalid number which should produce a 400 Bad Request', () => {
         it('Returns HTTP 400 status', (done) => {
@@ -67,6 +68,7 @@ describe('Pin Creation API Tests', () => {
                         logger.error(`error raised: ${err} using URL ${pinServiceUrl}`);
                     } else {
                         expect(err).to.be.equal(null);
+                        expect(res.text).to.match(numberMatchRE);
                         expect(res.header).to.have.property('content-length').eq(VALID_PIN_CONTENT_LENGTH);
                         expect(res.text).is.not.equal(null);
                     }
@@ -87,6 +89,7 @@ describe('Pin Creation API Tests', () => {
                         logger.error(`error raised: ${err} using URL ${pinServiceUrl}`);
                     } else {
                         expect(err).to.be.equal(null);
+                        expect(res.text).to.match(numberMatchRE);
                         expect(res.header).to.have.property('content-length').eq(VALID_PIN_CONTENT_LENGTH);
                         expect(res.text).is.not.equal(null);
                     }
@@ -107,6 +110,7 @@ describe('Pin Creation API Tests', () => {
                         logger.error(`error raised: ${err} using URL ${pinServiceUrl}`);
                     } else {
                         expect(err).to.be.equal(null);
+                        expect(res.text).to.match(numberMatchRE);
                         expect(res.header).to.have.property('content-length').eq(VALID_PIN_CONTENT_LENGTH);
                         expect(res.text).is.not.equal(null);
                     }

--- a/test/contract/generatepin/testGeneratePin.js
+++ b/test/contract/generatepin/testGeneratePin.js
@@ -17,7 +17,7 @@ const VALID_PIN_CONTENT_LENGTH = '6';
 describe('Pin Creation API Tests', () => {
 
     const pinServiceUrl = FormatUrl.format(TEST_VALIDATION_SERVICE_URL, '/pin');
-    const numberMatchRE = new RegExp(/[0-9]+/);
+    const numberMatchRE = new RegExp(/^[0-9]+$/);
 
     describe('Invalid number which should produce a 400 Bad Request', () => {
         it('Returns HTTP 400 status', (done) => {

--- a/test/contract/generatepin/testGeneratePin.js
+++ b/test/contract/generatepin/testGeneratePin.js
@@ -67,6 +67,7 @@ describe('Pin Creation API Tests', () => {
                     if (err) {
                         logger.error(`error raised: ${err} using URL ${pinServiceUrl}`);
                     } else {
+                        logger.error('RESPONSE: ' + JSON.stringify(res));
                         expect(err).to.be.equal(null);
                         expect(res.text).to.match(numberMatchRE);
                         expect(res.header).to.have.property('content-length').eq(VALID_PIN_CONTENT_LENGTH);
@@ -88,6 +89,7 @@ describe('Pin Creation API Tests', () => {
                     if (err) {
                         logger.error(`error raised: ${err} using URL ${pinServiceUrl}`);
                     } else {
+                        logger.error('RESPONSE: ' + JSON.stringify(res));
                         expect(err).to.be.equal(null);
                         expect(res.text).to.match(numberMatchRE);
                         expect(res.header).to.have.property('content-length').eq(VALID_PIN_CONTENT_LENGTH);
@@ -109,6 +111,7 @@ describe('Pin Creation API Tests', () => {
                     if (err) {
                         logger.error(`error raised: ${err} using URL ${pinServiceUrl}`);
                     } else {
+                        logger.error('RESPONSE: ' + JSON.stringify(res));
                         expect(err).to.be.equal(null);
                         expect(res.text).to.match(numberMatchRE);
                         expect(res.header).to.have.property('content-length').eq(VALID_PIN_CONTENT_LENGTH);


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PRO-3459

### Change description ###
Update to PRO-3459 to include an extra check for the test response to be an actual number. It would appear sometimes the text response from Notify is returning an error message and this ends up being passed back to the frontend application. With the check in place any messages from Notify which do not match a numerical value will be shown in the console logs.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
