### PR TITLE
PRO-3812 - Feature Toggling causes application error page to be displayed

### DIFF
--- a/app/steps/ui/applicant/alias/index.js
+++ b/app/steps/ui/applicant/alias/index.js
@@ -11,7 +11,7 @@ class ApplicantAlias extends ValidationStep {
 
     isComplete(ctx, formdata, featureToggles) {
         const isEnabled = FeatureToggle.isEnabled(featureToggles, 'main_applicant_alias');
-        return [isEnabled ? this.validate()[0] : true, 'noProgress'];
+        return [isEnabled ? this.validate(ctx, formdata)[0] : true, 'inProgress'];
     }
 }
 

--- a/app/steps/ui/applicant/aliasreason/index.js
+++ b/app/steps/ui/applicant/aliasreason/index.js
@@ -11,7 +11,7 @@ class ApplicantAliasReason extends ValidationStep {
 
     isComplete(ctx, formdata, featureToggles) {
         const isEnabled = FeatureToggle.isEnabled(featureToggles, 'main_applicant_alias');
-        return [isEnabled ? this.validate()[0] : true, 'noProgress'];
+        return [isEnabled ? this.validate(ctx, formdata)[0] : true, 'inProgress'];
     }
 }
 

--- a/test/unit/testApplicantAlias.js
+++ b/test/unit/testApplicantAlias.js
@@ -16,13 +16,35 @@ describe('ApplicantAlias', () => {
     });
 
     describe('isComplete()', () => {
+        describe('should return the correct data when the feature toggle exists', () => {
+            it('and is enabled and the field value exists', (done) => {
+                const ApplicantAlias = steps.ApplicantAlias;
+                const ctx = {alias: 'harry potter'};
+                const formdata = {};
+                const featureToggles = {main_applicant_alias: true};
+                const isComplete = ApplicantAlias.isComplete(ctx, formdata, featureToggles);
+                expect(isComplete).to.deep.equal([true, 'inProgress']);
+                done();
+            });
+
+            it('and is disabled', (done) => {
+                const ApplicantAlias = steps.ApplicantAlias;
+                const ctx = {};
+                const formdata = {};
+                const featureToggles = {main_applicant_alias: false};
+                const isComplete = ApplicantAlias.isComplete(ctx, formdata, featureToggles);
+                expect(isComplete).to.deep.equal([true, 'inProgress']);
+                done();
+            });
+        });
+
         it('should return the correct data when the feature toggle does not exist', (done) => {
             const ApplicantAlias = steps.ApplicantAlias;
             const ctx = {};
             const formdata = {};
             const featureToggles = {};
             const isComplete = ApplicantAlias.isComplete(ctx, formdata, featureToggles);
-            expect(isComplete).to.deep.equal([true, 'noProgress']);
+            expect(isComplete).to.deep.equal([true, 'inProgress']);
             done();
         });
     });

--- a/test/unit/testApplicantAliasReason.js
+++ b/test/unit/testApplicantAliasReason.js
@@ -16,13 +16,35 @@ describe('ApplicantAliasReason', () => {
     });
 
     describe('isComplete()', () => {
+        describe('should return the correct data when the feature toggle exists', () => {
+            it('and is enabled and the field value exists', (done) => {
+                const ApplicantAliasReason = steps.ApplicantAliasReason;
+                const ctx = {aliasReason: 'Divorce'};
+                const formdata = {};
+                const featureToggles = {main_applicant_alias: true};
+                const isComplete = ApplicantAliasReason.isComplete(ctx, formdata, featureToggles);
+                expect(isComplete).to.deep.equal([true, 'inProgress']);
+                done();
+            });
+
+            it('and is disabled', (done) => {
+                const ApplicantAliasReason = steps.ApplicantAliasReason;
+                const ctx = {};
+                const formdata = {};
+                const featureToggles = {main_applicant_alias: false};
+                const isComplete = ApplicantAliasReason.isComplete(ctx, formdata, featureToggles);
+                expect(isComplete).to.deep.equal([true, 'inProgress']);
+                done();
+            });
+        });
+
         it('should return the correct data when the feature toggle does not exist', (done) => {
             const ApplicantAliasReason = steps.ApplicantAliasReason;
             const ctx = {};
             const formdata = {};
             const featureToggles = {};
             const isComplete = ApplicantAliasReason.isComplete(ctx, formdata, featureToggles);
-            expect(isComplete).to.deep.equal([true, 'noProgress']);
+            expect(isComplete).to.deep.equal([true, 'inProgress']);
             done();
         });
     });


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/PRO-3812

### Change description ###

Fixed `isComplete()` for `applicant-alias` and `applicant-alias-reason` pages for when the feature toggle is switched on by adding `ctx` and `formdata` params to `validate()` because otherwise its not got anything to validate

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
