### PR TITLE
[PREVIEW] PRO-3858: Update to add regId as applicantEmail in formdata when crea…

### DIFF
--- a/app/components/security.js
+++ b/app/components/security.js
@@ -40,6 +40,11 @@ class Security {
                             req.session.regId = response.email;
                             req.userId = response.id;
                             req.authToken = securityCookie;
+
+                            if (typeof req.session.regId !== 'string') {
+                                logger.error('req.session.regId is empty after login');
+                            }
+
                             self._authorize(res, next, response.roles, authorisedRoles);
                         } else {
                             logger.error('Error authorising user');

--- a/app/routes.js
+++ b/app/routes.js
@@ -13,6 +13,7 @@ const featureToggles = require('app/featureToggles');
 router.all('*', (req, res, next) => {
     req.log = logger(req.sessionID);
     req.log.info(`Processing ${req.method} for ${req.originalUrl}`);
+    req.log.info(`req.session.regId is set: ${typeof req.session.regId === 'string'}`);
     next();
 });
 

--- a/app/steps/ui/payment/breakdown/index.js
+++ b/app/steps/ui/payment/breakdown/index.js
@@ -51,12 +51,12 @@ class PaymentBreakdown extends Step {
     * handlePost(ctx, errors, formdata, session, hostname) {
         if (formdata.paymentPending !== 'unknown') {
             if (!formdata.applicantEmail) {
-                logger.warn('Unable to find applicantEmail, using regId ${session.regId} instead.');   
-                if (session.regId !== undefined) {
+                logger.warn('Unable to find applicantEmail, using session.regId instead.');
+                if (session.regId) {
                     formdata.applicantEmail = session.regId;
+                } else {
+                    logger.error('Unable to find applicantEmail or session.regId.');
                 }
-            } else {
-                logger.error('Unable to find applicantEmail or session.regId.'); 
             }
             const result = yield this.sendToSubmitService(ctx, errors, formdata, ctx.total);
             if (errors.length > 0) {
@@ -127,7 +127,7 @@ class PaymentBreakdown extends Step {
         return [['true', 'false'].includes(formdata.paymentPending), 'inProgress'];
     }
 
-    * sendToSubmitService(ctx, errors, formdata, total, regId) {
+    * sendToSubmitService(ctx, errors, formdata, total) {
         const softStop = this.anySoftStops(formdata, ctx) ? 'softStop' : false;
         set(formdata, 'payment.total', total);
         const result = yield services.sendToSubmitService(formdata, ctx, softStop);

--- a/app/steps/ui/payment/breakdown/index.js
+++ b/app/steps/ui/payment/breakdown/index.js
@@ -50,6 +50,14 @@ class PaymentBreakdown extends Step {
 
     * handlePost(ctx, errors, formdata, session, hostname) {
         if (formdata.paymentPending !== 'unknown') {
+            if (!formdata.applicantEmail) {
+                logger.warn('Unable to find applicantEmail, using regId ${session.regId} instead.');   
+                if (session.regId !== undefined) {
+                    formdata.applicantEmail = session.regId;
+                }
+            } else {
+                logger.error('Unable to find applicantEmail or session.regId.'); 
+            }
             const result = yield this.sendToSubmitService(ctx, errors, formdata, ctx.total);
             if (errors.length > 0) {
                 logger.error('Failed to create case in CCD.');
@@ -119,7 +127,7 @@ class PaymentBreakdown extends Step {
         return [['true', 'false'].includes(formdata.paymentPending), 'inProgress'];
     }
 
-    * sendToSubmitService(ctx, errors, formdata, total) {
+    * sendToSubmitService(ctx, errors, formdata, total, regId) {
         const softStop = this.anySoftStops(formdata, ctx) ? 'softStop' : false;
         set(formdata, 'payment.total', total);
         const result = yield services.sendToSubmitService(formdata, ctx, softStop);

--- a/test/unit/testPaymentBreakdown.js
+++ b/test/unit/testPaymentBreakdown.js
@@ -31,7 +31,7 @@ describe('PaymentBreakdown', () => {
             const PaymentBreakdown = steps.PaymentBreakdown;
             let ctx = {total: 0};
             let errors = [];
-            const formdata = {};
+            const formdata = {applicantEmail: 'test@email.com'};
 
             co(function* () {
                 [ctx, errors] = yield PaymentBreakdown.handlePost(ctx, errors, formdata);
@@ -69,6 +69,7 @@ describe('PaymentBreakdown', () => {
                 creatingPayment: 'true'
             };
             const session = {
+                regId: 'test@email.com',
                 save: () => true
             };
 
@@ -76,10 +77,10 @@ describe('PaymentBreakdown', () => {
                 const [ctx, errors] = yield PaymentBreakdown.handlePost(ctxTestData,
                     errorsTestData, formdata, session, hostname);
                 assert.deepEqual(formdata, {
+                    'applicantEmail': 'test@email.com',
                     'ccdCase': {
                         'id': 1535395401245028,
                         'state': 'PaAppCreated'
-
             },
                     'creatingPayment': 'true',
                     'payment': {
@@ -129,6 +130,7 @@ describe('PaymentBreakdown', () => {
                 creatingPayment: 'false'
             };
             const session = {
+                regId: 'test@email.com',
                 save: () => true
             };
 
@@ -136,6 +138,7 @@ describe('PaymentBreakdown', () => {
                 const [ctx, errors] = yield PaymentBreakdown.handlePost(ctxTestData,
                     errorsTestData, formdata, session, hostname);
                 assert.deepEqual(formdata, {
+                    'applicantEmail': 'test@email.com',
                     'ccdCase': {
                         'id': 1535395401245028,
                         'state': 'PaAppCreated'
@@ -190,6 +193,7 @@ describe('PaymentBreakdown', () => {
             const ctxTestData = {total: 215};
             const errorsTestData = [];
             const formdata = {
+                applicantEmail: 'test@email.com',
                 creatingPayment: 'false'
             };
             const session = {
@@ -200,6 +204,7 @@ describe('PaymentBreakdown', () => {
                 const [ctx, errors] = yield PaymentBreakdown.handlePost(ctxTestData,
                     errorsTestData, formdata, session, hostname);
                 assert.deepEqual(formdata, {
+                    'applicantEmail': 'test@email.com',
                     'ccdCase': {
                         'id': 1535395401245028,
                         'state': 'PaAppCreated'


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PRO-3858

### Change description ###
Update to ensure the formdata.applicantEmail is available prior to creating a case. If the applicantEmail is missing the data is retrieved from the req.session.regId which also holds the applicants email address, although in development environments with no IdAM this value is the sessionId.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
