### PR TITLE
[PREVIEW] PRO-3858 - Users being prevented from reaching payment screen after probate release

### DIFF
--- a/app/components/security.js
+++ b/app/components/security.js
@@ -40,11 +40,6 @@ class Security {
                             req.session.regId = response.email;
                             req.userId = response.id;
                             req.authToken = securityCookie;
-
-                            if (typeof req.session.regId !== 'string') {
-                                logger.error('req.session.regId is empty after login');
-                            }
-
                             self._authorize(res, next, response.roles, authorisedRoles);
                         } else {
                             logger.error('Error authorising user');

--- a/app/routes.js
+++ b/app/routes.js
@@ -13,7 +13,6 @@ const featureToggles = require('app/featureToggles');
 router.all('*', (req, res, next) => {
     req.log = logger(req.sessionID);
     req.log.info(`Processing ${req.method} for ${req.originalUrl}`);
-    req.log.info(`req.session.regId is set: ${typeof req.session.regId === 'string'}`);
     next();
 });
 
@@ -25,6 +24,11 @@ router.use((req, res, next) => {
         };
         req.session.back = [];
     }
+
+    if (!req.session.form.applicantEmail) {
+        req.session.form.applicantEmail = req.session.regId;
+    }
+
     next();
 });
 

--- a/app/steps/ui/payment/breakdown/index.js
+++ b/app/steps/ui/payment/breakdown/index.js
@@ -50,14 +50,6 @@ class PaymentBreakdown extends Step {
 
     * handlePost(ctx, errors, formdata, session, hostname) {
         if (formdata.paymentPending !== 'unknown') {
-            if (!formdata.applicantEmail) {
-                logger.warn('Unable to find applicantEmail, using session.regId instead.');
-                if (session.regId) {
-                    formdata.applicantEmail = session.regId;
-                } else {
-                    logger.error('Unable to find applicantEmail or session.regId.');
-                }
-            }
             const result = yield this.sendToSubmitService(ctx, errors, formdata, ctx.total);
             if (errors.length > 0) {
                 logger.error('Failed to create case in CCD.');

--- a/test/unit/testPaymentBreakdown.js
+++ b/test/unit/testPaymentBreakdown.js
@@ -31,7 +31,7 @@ describe('PaymentBreakdown', () => {
             const PaymentBreakdown = steps.PaymentBreakdown;
             let ctx = {total: 0};
             let errors = [];
-            const formdata = {applicantEmail: 'test@email.com'};
+            const formdata = {};
 
             co(function* () {
                 [ctx, errors] = yield PaymentBreakdown.handlePost(ctx, errors, formdata);
@@ -69,7 +69,6 @@ describe('PaymentBreakdown', () => {
                 creatingPayment: 'true'
             };
             const session = {
-                regId: 'test@email.com',
                 save: () => true
             };
 
@@ -77,7 +76,6 @@ describe('PaymentBreakdown', () => {
                 const [ctx, errors] = yield PaymentBreakdown.handlePost(ctxTestData,
                     errorsTestData, formdata, session, hostname);
                 assert.deepEqual(formdata, {
-                    'applicantEmail': 'test@email.com',
                     'ccdCase': {
                         'id': 1535395401245028,
                         'state': 'PaAppCreated'
@@ -130,7 +128,6 @@ describe('PaymentBreakdown', () => {
                 creatingPayment: 'false'
             };
             const session = {
-                regId: 'test@email.com',
                 save: () => true
             };
 
@@ -138,7 +135,6 @@ describe('PaymentBreakdown', () => {
                 const [ctx, errors] = yield PaymentBreakdown.handlePost(ctxTestData,
                     errorsTestData, formdata, session, hostname);
                 assert.deepEqual(formdata, {
-                    'applicantEmail': 'test@email.com',
                     'ccdCase': {
                         'id': 1535395401245028,
                         'state': 'PaAppCreated'
@@ -193,7 +189,6 @@ describe('PaymentBreakdown', () => {
             const ctxTestData = {total: 215};
             const errorsTestData = [];
             const formdata = {
-                applicantEmail: 'test@email.com',
                 creatingPayment: 'false'
             };
             const session = {
@@ -204,7 +199,6 @@ describe('PaymentBreakdown', () => {
                 const [ctx, errors] = yield PaymentBreakdown.handlePost(ctxTestData,
                     errorsTestData, formdata, session, hostname);
                 assert.deepEqual(formdata, {
-                    'applicantEmail': 'test@email.com',
                     'ccdCase': {
                         'id': 1535395401245028,
                         'state': 'PaAppCreated'


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/PRO-3858

### Change description ###

We need to do this because the formdata gets set without the applicantEmail during the screener questions and the applicantEmail needs to be set after returning from IDAM

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```