### PR TITLE
[PREVIEW] PRO-3755 - Upload death certificate - Max Files

### DIFF
--- a/app.js
+++ b/app.js
@@ -63,7 +63,11 @@ exports.init = function() {
         'enableTracking': config.enableTracking,
         'links': config.links,
         'helpline': config.helpline,
-        'nonce': uuid
+        'nonce': uuid,
+        'documentUpload': {
+            fileTypes: config.documentUpload.fileTypes,
+            maxFiles: config.documentUpload.maxFiles,
+        }
     };
 
     const njk = nunjucks(app, {

--- a/app/config.js
+++ b/app/config.js
@@ -148,6 +148,10 @@ const config = {
     },
     appInsights: {
         instrumentationKey: process.env.APPINSIGHTS_INSTRUMENTATIONKEY
+    },
+    documentUpload: {
+        fileTypes: '.jpg,.jpeg,.bmp,.tiff,.tif,.png,.pdf',
+        maxFiles: 10
     }
 };
 

--- a/app/resources/en/translation/common.json
+++ b/app/resources/en/translation/common.json
@@ -46,5 +46,7 @@
   "documentUploadNoFilesUploaded": "No files uploaded",
   "documentUploadRemoveFile": "Remove",
   "documentUploadInvalidFileTypeSummary": "You have used a file type that can’t be accepted",
-  "documentUploadInvalidFileType": "Save your file as a jpg, bmp, tiff, png or PDF file and try again"
+  "documentUploadInvalidFileType": "Save your file as a jpg, bmp, tiff, png or PDF file and try again",
+  "documentUploadMaxFilesExceededSummary": "You have uploaded too many files",
+  "documentUploadMaxFilesExceeded": "You can upload a maximum of {maxFiles} files"
 }

--- a/app/views/includes/scripts.html
+++ b/app/views/includes/scripts.html
@@ -17,12 +17,16 @@
 
 <script src="/public/javascripts/dropzone.js"></script>
 <script nonce="{{nonce}}">
-    var documentUploadContent = {
+    var documentUploadConfig = {
         csrfToken: "{{csrfToken}}",
         removeFileText: "{{common.documentUploadRemoveFile}}",
         invalidFileType: "{{common.documentUploadInvalidFileType}}",
         errorSummaryHeading: "{{common.errorSummaryHeading}}",
-        invalidFileTypeSummary: "{{common.documentUploadInvalidFileTypeSummary}}"
+        invalidFileTypeSummary: "{{common.documentUploadInvalidFileTypeSummary}}",
+        maxFilesExceeded: "{{common.documentUploadMaxFilesExceeded}}".replace('{maxFiles}', "{{documentUpload.maxFiles}}"),
+        maxFilesExceededSummary: "{{common.documentUploadMaxFilesExceededSummary}}",
+        fileTypes: "{{documentUpload.fileTypes}}",
+        maxFiles: "{{documentUpload.maxFiles}}"
     };
 </script>
 <script src="/public/javascripts/document-upload.js"></script>


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/PRO-3755

### Change description ###

**Add validation for the number of files.**

- Only 10 files may be uploaded and this should work when using the files selector and dragging/dropping.

- If you have multiple error messages displaying on the file list and you remove all the files for an error message then the error summary is also updated to remove reference to that error message.

- If you drag 12 files into the Dropzone and get 2 error messages then remove 2 of the uploaded files, the error messages remain even though you've now only uploaded 8 files...discussed and agreed with Femi and Davy.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```