### PR TITLE
[PREVIEW] PRO-3749 - Upload death certificate - Non-JS

### DIFF
--- a/app/assets/javascripts/document-upload.js
+++ b/app/assets/javascripts/document-upload.js
@@ -1,11 +1,13 @@
 $(document).ready(function () {
     DocumentUpload.initDropzone();
+    DocumentUpload.displayWidgetElements();
+    DocumentUpload.makeDropzoneLinkClickable();
 });
 
 var DocumentUpload = {
     initDropzone: function() {
         new Dropzone('.document-upload__dropzone', {
-            url: '/upload-document',
+            url: '/upload-document/add',
             previewsContainer: '.document-upload__preview',
             headers: {
                 'x-csrf-token': documentUploadConfig.csrfToken
@@ -36,7 +38,6 @@ var DocumentUpload = {
         .on('queuecomplete', function(file) {
             DocumentUpload.enableSubmitButton();
         });
-        DocumentUpload.makeDropzoneLinkClickable();
     },
     makeDropzoneLinkClickable: function() {
         $('.document-upload__dropzone-text--choose-file').click(function() {
@@ -50,13 +51,18 @@ var DocumentUpload = {
             }
         })[0];
     },
+    displayWidgetElements: function() {
+        $('.document-upload__text').addClass('document-upload__text--javascript');
+        $('.document-upload__image').addClass('document-upload__image--javascript');
+        $('.document-upload__dropzone').addClass('document-upload__dropzone--javascript');
+    },
     showEmptyListMessage: function() {
         if ($('.dz-preview').length === 0) {
-            $('.document-upload__no-files-uploaded-text').show();
+            $('.document-upload__empty-list-text').show();
         }
     },
     hideEmptyListMessage: function() {
-        $('.document-upload__no-files-uploaded-text').hide();
+        $('.document-upload__empty-list-text').hide();
     },
     showErrorSummary: function() {
         if ($('.error-summary').length === 0) {

--- a/app/assets/sass/patterns/_document-upload.scss
+++ b/app/assets/sass/patterns/_document-upload.scss
@@ -88,3 +88,9 @@
   height: 5px;
   margin-top: 8px;
 }
+.dz-processing [data-dz-uploadprogress] {
+  background-color: $govuk-blue;
+  display: block;
+  height: 5px;
+  margin-top: 8px;
+}

--- a/app/assets/sass/patterns/_document-upload.scss
+++ b/app/assets/sass/patterns/_document-upload.scss
@@ -1,16 +1,26 @@
-.document-upload__dropzone {
+.document-upload__dropzone--javascript {
   border: 2px dashed $grey-1;
   overflow: hidden;
   padding: 30px;
 }
 
 .document-upload__image {
-  width: 90px;
+  display: none;
+}
+
+.document-upload__image--javascript {
+  display: block;
   float: left;
   margin-left: 100px;
+  width: 90px;
 }
 
 .document-upload__text {
+  display: none;
+}
+
+.document-upload__text--javascript {
+  display: block;
   float: left;
   padding-top: 4px;
 }
@@ -76,18 +86,6 @@
   @include bold-19;
 }
 
-.dz-processing [data-dz-uploadprogress] {
-  background-color: $govuk-blue;
-  display: block;
-  height: 5px;
-  margin-top: 8px;
-}
-.dz-processing [data-dz-uploadprogress] {
-  background-color: $govuk-blue;
-  display: block;
-  height: 5px;
-  margin-top: 8px;
-}
 .dz-processing [data-dz-uploadprogress] {
   background-color: $govuk-blue;
   display: block;

--- a/app/documentUpload.js
+++ b/app/documentUpload.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const router = require('express').Router();
+const services = require('app/components/services');
+const DocumentUpload = require('app/utils/DocumentUpload');
+
+router.post('/add', (req, res) => {
+    const uploadedFile = req.body.file;
+    let formdata = req.session.form;
+    services.uploadDocument(req.session.id);
+    formdata = DocumentUpload.initDocuments(formdata);
+    formdata.documents.uploads = DocumentUpload.addDocument(uploadedFile, formdata.documents.uploads);
+    res.redirect('/document-upload');
+});
+
+router.get('/remove/:index', (req, res) => {
+    const uploads = req.session.form.documents.uploads;
+    req.session.form.documents.uploads = DocumentUpload.removeDocument(req.params.index, uploads);
+    res.redirect('/document-upload');
+});
+
+module.exports = router;

--- a/app/resources/en/translation/common.json
+++ b/app/resources/en/translation/common.json
@@ -43,12 +43,13 @@
   "documentUploadChooseFile": "Choose a file or take a photo",
   "documentUploadDragAndDrop": "drag and drop files here",
   "documentUploadPreviewTitle": "Uploaded files",
-  "documentUploadNoFilesUploaded": "No files uploaded",
+  "documentUploadEmptyList": "No files uploaded",
   "documentUploadRemoveFile": "Remove",
   "documentUploadInvalidFileTypeSummary": "You have used a file type that can’t be accepted",
   "documentUploadInvalidFileType": "Save your file as a jpg, bmp, tiff, png or PDF file and try again",
   "documentUploadMaxFilesExceededSummary": "You have uploaded too many files",
   "documentUploadMaxFilesExceeded": "You can upload a maximum of {maxFiles} files",
   "documentUploadMaxFileSizeSummary": "Your file is too large to upload",
-  "documentUploadMaxFileSize": "Use a file that is under {maxFileSize}MB and try again"
+  "documentUploadMaxFileSize": "Use a file that is under {maxFileSize}MB and try again",
+  "documentUploadUploadDocument": "Upload document"
 }

--- a/app/routes.js
+++ b/app/routes.js
@@ -9,6 +9,7 @@ const {get, includes, isEqual} = require('lodash');
 const commonContent = require('app/resources/en/translation/common');
 const ExecutorsWrapper = require('app/wrappers/Executors');
 const featureToggles = require('app/featureToggles');
+const documentUpload = require('app/documentUpload');
 
 router.all('*', (req, res, next) => {
     req.log = logger(req.sessionID);
@@ -84,10 +85,7 @@ router.use((req, res, next) => {
 
 router.use(featureToggles);
 
-router.post('/upload-document', (req, res) => {
-    services.uploadDocument(req.session.id);
-    res.send('File uploaded successfully');
-});
+router.use('/upload-document', documentUpload);
 
 router.use((req, res, next) => {
     res.locals.session = req.session;

--- a/app/steps/ui/documentupload/index.js
+++ b/app/steps/ui/documentupload/index.js
@@ -7,6 +7,14 @@ class DocumentUpload extends ValidationStep {
     static getUrl() {
         return '/document-upload';
     }
+
+    handleGet(ctx, formdata) {
+        if (formdata.documents) {
+            ctx.uploadedFiles = formdata.documents.uploads;
+        }
+
+        return [ctx];
+    }
 }
 
 module.exports = DocumentUpload;

--- a/app/steps/ui/documentupload/template.html
+++ b/app/steps/ui/documentupload/template.html
@@ -6,14 +6,11 @@
     <h1 class="form-title heading-large">{{content.header}}</h1>
 {% endblock %}
 
-{% block form_content %}
-
+{% block page_content %}
     <p>{{ content.paragraph1 }}</p>
-
     <div class="panel panel-border-wide">
         <p>{{ content.help }}</p>
     </div>
-
     <details class="help-panel">
         <summary><span class="summary">{{ content.stepsTitle }}</span></summary>
         <div class="panel panel-border-narrow">
@@ -25,7 +22,6 @@
             ]) }}
         </div>
     </details>
-
     <p>{{ content.paragraph2 }}</p>
 
     {% include "includes/document-upload.html" %}
@@ -36,7 +32,9 @@
             <p>{{ content.cantUploadDocumentsText | safe }}</p>
         </div>
     </details>
+{% endblock %}
 
+{% block form_content %}
     <div class="form-group">
         <input id="button" class="button" type="submit" role="button" value="{{ common.continue }}">
     </div>

--- a/app/utils/DocumentUpload.js
+++ b/app/utils/DocumentUpload.js
@@ -1,0 +1,26 @@
+'use strict';
+
+class DocumentUpload {
+    static initDocuments(formdata) {
+        if (!formdata.documents) {
+            formdata.documents = {};
+        }
+        return formdata;
+    }
+
+    static addDocument(uploadedFile, uploads = []) {
+        if (uploadedFile) {
+            uploads.push(uploadedFile);
+        }
+        return uploads;
+    }
+
+    static removeDocument(index, uploads) {
+        if (!isNaN(index)) {
+            uploads.splice(index, 1);
+        }
+        return uploads;
+    }
+}
+
+module.exports = DocumentUpload;

--- a/app/views/includes/document-upload.html
+++ b/app/views/includes/document-upload.html
@@ -6,9 +6,42 @@
             <p class="document-upload__dropzone-text bold">{{ common.or }}</p>
             <p class="document-upload__dropzone-text">{{ common.documentUploadDragAndDrop }}</p>
         </div>
+        <div class="document-upload__fallback fallback">
+            <form class="form" method="post" action="/upload-document/add" novalidate>
+                <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+                <div class="form-group">
+                    <label for="file" class="visually-hidden">{{ content.title }}</label>
+                    <input name="file" type="file" id="file">
+                </div>
+                <div class="form-group">
+                    <input id="button" class="button-secondary" type="submit" role="button" value="{{ common.documentUploadUploadDocument }}">
+                </div>
+            </form>
+        </div>
     </div>
     <div class="document-upload__preview" id="uploaded-files">
         <h2 class="heading-medium">{{ common.documentUploadPreviewTitle }}</h2>
-        <p class="document-upload__no-files-uploaded-text">{{ common.documentUploadNoFilesUploaded }}</p>
+
+        {% if (fields.uploadedFiles.value === undefined or fields.uploadedFiles.value.length === 0) %}
+            <p class="document-upload__empty-list-text">{{ common.documentUploadEmptyList }}</p>
+        {% endif %}
+
+        {% for file in fields.uploadedFiles.value %}
+            <div class="dz-preview dz-file-preview">
+                <div class="dz-error-message">
+                    <span data-dz-errormessage></span>
+                </div>
+                <div class="dz-details">
+                    <div class="dz-filename">
+                        <span data-dz-name>{{ file }}</span>
+                    </div>
+                </div>
+                <div class="dz-progress">
+                    <span class="dz-upload" data-dz-uploadprogress></span>
+                </div>
+                <a class="dz-remove" href="/upload-document/remove/{{ loop.index0 }}">{{ common.documentUploadRemoveFile }}</a>
+            </div>
+        {% endfor %}
+
     </div>
 </div>

--- a/app/views/includes/two_thirds_form.html
+++ b/app/views/includes/two_thirds_form.html
@@ -1,21 +1,26 @@
 {% extends "includes/layout.html" %}
 
 {% block content %}
-
 <main id="content" role="main">
+
     {% include "includes/phase_banner_beta.html" %}
 
     <div class="grid-row">
         <div class="column-two-thirds">
+
             {% block error_summary %}
                 {% include "includes/error_summary.html" %}
             {% endblock %}
+
             {% block question %}{% endblock %}
+
+            {% block page_content %}{% endblock %}
 
             <form class="form" method="post" action="{{pageUrl}}" novalidate>
                 <input type="hidden" name="_csrf" value="{{csrfToken}}">
                 {% block form_content %}{% endblock %}
             </form>
+
             {% block save_and_close %}<p><a href="/sign-out">{{common.saveAndClose}}</a></p>{% endblock %}
 
             {% block executor_summary %}{% endblock %}

--- a/test/unit/testDocumentUploadUtil.js
+++ b/test/unit/testDocumentUploadUtil.js
@@ -1,0 +1,68 @@
+'use strict';
+
+const DocumentUpload = require('app/utils/DocumentUpload');
+const expect = require('chai').expect;
+
+describe('DocumentUpload.js', () => {
+    describe('initDocuments()', () => {
+        it('should return formdata.documents when formdata.documents does not exist', (done) => {
+            const testFormdata = {};
+            const formdata = DocumentUpload.initDocuments(testFormdata);
+            expect(formdata).to.deep.equal({
+                documents: {}
+            });
+            done();
+        });
+
+        it('should return the original formdata.documents when formdata.documents exists', (done) => {
+            const testFormdata = {
+                documents: {
+                    sentDocuments: true
+                }
+            };
+            const formdata = DocumentUpload.initDocuments(testFormdata);
+            expect(formdata).to.deep.equal({
+                documents: {
+                    sentDocuments: true
+                }
+            });
+            done();
+        });
+    });
+
+    describe('addDocument()', () => {
+        it('should return an array of documents containing a new document when a document is given', (done) => {
+            const uploadedFile = 'death-certificate.pdf';
+            const testUploads = [
+                'will.pdf'
+            ];
+            const uploads = DocumentUpload.addDocument(uploadedFile, testUploads);
+            expect(uploads).to.deep.equal([
+                'will.pdf',
+                'death-certificate.pdf'
+            ]);
+            done();
+        });
+
+        it('should return an array of documents without an undefined value when a document is not given', (done) => {
+            const uploadedFile = null;
+            const testUploads = [
+                'will.pdf'
+            ];
+            const uploads = DocumentUpload.addDocument(uploadedFile, testUploads);
+            expect(uploads).to.deep.equal([
+                'will.pdf'
+            ]);
+            done();
+        });
+
+        it('should create and return an array of documents when an array of documents does not exist and a document is given', (done) => {
+            const uploadedFile = 'death-certificate.pdf';
+            const uploads = DocumentUpload.addDocument(uploadedFile);
+            expect(uploads).to.deep.equal([
+                'death-certificate.pdf'
+            ]);
+            done();
+        });
+    });
+});


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/PRO-3749

### Change description ###

Add javascript fallback for when javascript is disabled.

Files can be added one at a time by selecting a file and clicking 'Upload document'. As a file is uploaded it is displayed in the list below the file upload form.

The files are saved into the session so the file list is displayed when refreshing the page.

Validation is done in the following stories.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```