### PR TITLE
PRO-3915: Stop duplicate payments

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -55,9 +55,9 @@ const config = {
         },
         payment: {
             createPaymentUrl: process.env.PAYMENT_CREATE_URL || 'http://localhost:8383/card-payments',
-            authorization: process.env.PAYMENT_AUTHORIZATION || 'dummy_token',
-            serviceAuthorization: process.env.PAYMENT_SERVICE_AUTHORIZATION || 'dummy_token',
-            userId: process.env.PAYMENT_USER_ID || 999999999,
+            authorization: process.env.PAYMENT_AUTHORIZATION || 'eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiJ2dTQ0YXFpYXN0a3B0NWdxM2NxMjNpdWtvcCIsInN1YiI6IjMzIiwiaWF0IjoxNTM5Njc3MzQwLCJleHAiOjE1Mzk3MDYxNDAsImRhdGEiOiJjYXNld29ya2VyLXByb2JhdGUsY2l0aXplbixjYXNld29ya2VyLGNhc2V3b3JrZXItcHJvYmF0ZS1sb2ExLGNpdGl6ZW4tbG9hMSxjYXNld29ya2VyLWxvYTEiLCJ0eXBlIjoiQUNDRVNTIiwiaWQiOiIzMyIsImZvcmVuYW1lIjoiVXNlciIsInN1cm5hbWUiOiJUZXN0IiwiZGVmYXVsdC1zZXJ2aWNlIjoiQ0NEIiwibG9hIjoxLCJkZWZhdWx0LXVybCI6Imh0dHBzOi8vbG9jYWxob3N0OjkwMDAvcG9jL2NjZCIsImdyb3VwIjoiY2FzZXdvcmtlciJ9.De5t59VpxKgqva6d81K7KkeYZkgDCxh8bU9p-hAf9cU',
+            serviceAuthorization: process.env.PAYMENT_SERVICE_AUTHORIZATION || 'eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJwcm9iYXRlX2Zyb250ZW5kIiwiZXhwIjoxNTM5NjkxNzQwfQ.50JRI8CuSL1N7-8V9azRgLP3TwRzbbFLxjQdd2neCJAu9N6RmlH2_q7XEvWcpPKKx4mki1tZ9y_KPGltQZmtSg',
+            userId: process.env.PAYMENT_USER_ID || 33,
             returnUrlPath: '/payment-status'
         }
     },

--- a/app/config.js
+++ b/app/config.js
@@ -55,9 +55,9 @@ const config = {
         },
         payment: {
             createPaymentUrl: process.env.PAYMENT_CREATE_URL || 'http://localhost:8383/card-payments',
-            authorization: process.env.PAYMENT_AUTHORIZATION || 'eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiJ2dTQ0YXFpYXN0a3B0NWdxM2NxMjNpdWtvcCIsInN1YiI6IjMzIiwiaWF0IjoxNTM5Njc3MzQwLCJleHAiOjE1Mzk3MDYxNDAsImRhdGEiOiJjYXNld29ya2VyLXByb2JhdGUsY2l0aXplbixjYXNld29ya2VyLGNhc2V3b3JrZXItcHJvYmF0ZS1sb2ExLGNpdGl6ZW4tbG9hMSxjYXNld29ya2VyLWxvYTEiLCJ0eXBlIjoiQUNDRVNTIiwiaWQiOiIzMyIsImZvcmVuYW1lIjoiVXNlciIsInN1cm5hbWUiOiJUZXN0IiwiZGVmYXVsdC1zZXJ2aWNlIjoiQ0NEIiwibG9hIjoxLCJkZWZhdWx0LXVybCI6Imh0dHBzOi8vbG9jYWxob3N0OjkwMDAvcG9jL2NjZCIsImdyb3VwIjoiY2FzZXdvcmtlciJ9.De5t59VpxKgqva6d81K7KkeYZkgDCxh8bU9p-hAf9cU',
-            serviceAuthorization: process.env.PAYMENT_SERVICE_AUTHORIZATION || 'eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJwcm9iYXRlX2Zyb250ZW5kIiwiZXhwIjoxNTM5NjkxNzQwfQ.50JRI8CuSL1N7-8V9azRgLP3TwRzbbFLxjQdd2neCJAu9N6RmlH2_q7XEvWcpPKKx4mki1tZ9y_KPGltQZmtSg',
-            userId: process.env.PAYMENT_USER_ID || 33,
+            authorization: process.env.PAYMENT_AUTHORIZATION || 'dummy_token',
+            serviceAuthorization: process.env.PAYMENT_SERVICE_AUTHORIZATION || 'dummy_token',
+            userId: process.env.PAYMENT_USER_ID || 999999999,
             returnUrlPath: '/payment-status'
         }
     },

--- a/app/steps/ui/payment/status/index.js
+++ b/app/steps/ui/payment/status/index.js
@@ -67,15 +67,17 @@ class PaymentStatus extends Step {
 
             const findPaymentResponse = yield services.findPayment(data);
             const date = typeof findPaymentResponse.date_updated === 'undefined' ? ctx.paymentCreatedDate : findPaymentResponse.date_updated;
-            Object.assign(formdata.payment, {
-                channel: findPaymentResponse.channel,
-                transactionId: findPaymentResponse.external_reference,
-                reference: findPaymentResponse.reference,
-                date: date,
-                amount: findPaymentResponse.amount,
-                status: findPaymentResponse.status,
-                siteId: findPaymentResponse.site_id
-            });
+            this.updateFormDataPayment(formdata, findPaymentResponse, date);
+            if (findPaymentResponse.name === 'Error' || findPaymentResponse.status === 'Initiated') {
+                logger.error('Payment retrieval failed for paymentId = ' + ctx.paymentId);
+                services.saveFormData(ctx.regId, formdata, ctx.sessionId);
+                const options = {};
+                options.redirect = true;
+                options.url = `${this.steps.PaymentBreakdown.constructor.getUrl()}?status=failure`;
+                formdata.paymentPending = 'true';
+                return options;
+            }
+
             const [updateCcdCaseResponse, errors] = yield this.updateCcdCasePaymentStatus(ctx, formdata);
             this.setErrors(options, errors);
             set(formdata, 'ccdCase.state', updateCcdCaseResponse.caseState);
@@ -125,6 +127,18 @@ class PaymentStatus extends Step {
         if (typeof errors !== 'undefined') {
             options.errors = errors;
         }
+    }
+
+    updateFormDataPayment(formdata, findPaymentResponse, date) {
+        Object.assign(formdata.payment, {
+            channel: findPaymentResponse.channel,
+            transactionId: findPaymentResponse.external_reference,
+            reference: findPaymentResponse.reference,
+            date: date,
+            amount: findPaymentResponse.amount,
+            status: findPaymentResponse.status,
+            siteId: findPaymentResponse.site_id
+        });
     }
 }
 

--- a/test/component/payment/testPaymentBreakdown.js
+++ b/test/component/payment/testPaymentBreakdown.js
@@ -1,7 +1,10 @@
 'use strict';
 
+const nock = require('nock');
+const config = require('app/config');
 const TestWrapper = require('test/util/TestWrapper');
 const testHelpBlockContent = require('test/component/common/testHelpBlockContent.js');
+const IDAM_S2S_URL = config.services.idam.s2s_url;
 
 describe('payment-breakdown', () => {
     let testWrapper;
@@ -10,6 +13,9 @@ describe('payment-breakdown', () => {
     beforeEach(() => {
         submitStub = require('test/service-stubs/submit');
         testWrapper = new TestWrapper('PaymentBreakdown');
+        nock(IDAM_S2S_URL).post('/lease')
+            .reply(200, 'eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJSRUZFUkVOQ0UifQ.Z_YYn0go02ApdSMfbehsLXXbxJxLugPG' +
+                '8v_3ktCpQurK8tHkOy1qGyTo02bTdilX4fq4M5glFh80edDuhDJXPA');
     });
 
     afterEach(() => {

--- a/test/unit/testPaymentBreakdown.js
+++ b/test/unit/testPaymentBreakdown.js
@@ -1,3 +1,4 @@
+// eslint-disable-line max-lines
 'use strict';
 
 const initSteps = require('app/core/initSteps');
@@ -321,7 +322,7 @@ describe('PaymentBreakdown', () => {
                     'creatingPayment': 'true',
                     'payment': {
                         'total': 215,
-                        "paymentId": "RC-12345"
+                        'paymentId': 'RC-12345'
                     },
                     'paymentPending': 'true',
                     'registry': {
@@ -373,7 +374,7 @@ describe('PaymentBreakdown', () => {
                     'creatingPayment': 'true',
                     'payment': {
                         'total': 215,
-                        "paymentId": "RC-12345"
+                        'paymentId': 'RC-12345'
                     },
                     'paymentPending': 'true',
                     'registry': {

--- a/test/unit/testPaymentBreakdown.js
+++ b/test/unit/testPaymentBreakdown.js
@@ -12,21 +12,47 @@ describe('PaymentBreakdown', () => {
     let authoriseStub;
     let sendToSubmitServiceStub;
     let createPaymentStub;
+    let findPaymentStub;
+
+    const successfulPaymentResponse = {
+        'channel': 'Online',
+        'id': 12345,
+        'reference': 'PaymentReference12345',
+        'amount': 5000,
+        'status': 'Success',
+        'date_updated': '2018-08-29T15:25:11.920+0000',
+        'site_id': 'siteId0001',
+        'external_reference': 12345
+    };
+
+    const initiatedPaymentResponse = {
+        'channel': 'Online',
+        'id': 12345,
+        'reference': 'PaymentReference12345',
+        'amount': 5000,
+        'status': 'Initiated',
+        'date_updated': '2018-08-29T15:25:11.920+0000',
+        'site_id': 'siteId0001',
+        'external_reference': 12345
+    };
 
     beforeEach(function () {
         authoriseStub = sinon.stub(services, 'authorise');
         sendToSubmitServiceStub = sinon.stub(services, 'sendToSubmitService');
         createPaymentStub = sinon.stub(services, 'createPayment');
+        findPaymentStub = sinon.stub(services, 'findPayment');
     });
 
     afterEach(function () {
         authoriseStub.restore();
         sendToSubmitServiceStub.restore();
         createPaymentStub.restore();
+        findPaymentStub.restore();
     });
 
     describe('handlePost', () => {
         it('sets paymentPending to false if ctx.total = 0', (done) => {
+            authoriseStub.returns(Promise.resolve({name: 'Success'}));
             sendToSubmitServiceStub.returns(submitResponse);
             const PaymentBreakdown = steps.PaymentBreakdown;
             let ctx = {total: 0};
@@ -44,6 +70,7 @@ describe('PaymentBreakdown', () => {
         });
 
         it('sets nextStepUrl to payment-status if paymentPending is unknown', (done) => {
+            authoriseStub.returns(Promise.resolve({name: 'Success'}));
             const PaymentBreakdown = steps.PaymentBreakdown;
             let ctx = {total: 1};
             let errors = [];
@@ -60,6 +87,7 @@ describe('PaymentBreakdown', () => {
         });
 
         it('sets paymentPending to true if ctx.total > 0', (done) => {
+            authoriseStub.returns(Promise.resolve({name: 'Success'}));
             sendToSubmitServiceStub.returns(submitResponse);
             const PaymentBreakdown = steps.PaymentBreakdown;
             const hostname = 'localhost';
@@ -234,6 +262,7 @@ describe('PaymentBreakdown', () => {
         });
 
         it('if sendToSubmitService returns DUPLICATE_SUBMISSION', (done) => {
+            authoriseStub.returns(Promise.resolve({name: 'Success'}));
             sendToSubmitServiceStub.returns(Promise.resolve('DUPLICATE_SUBMISSION'));
             const PaymentBreakdown = steps.PaymentBreakdown;
             const hostname = 'localhost';
@@ -256,6 +285,110 @@ describe('PaymentBreakdown', () => {
                         message: 'payment.breakdown.errors.submit.duplicate.message'
                     }
                 }]);
+                done();
+            })
+                .catch((err) => {
+                    done(err);
+                });
+        });
+
+        it('sets paymentPending to true if ctx.total > 0 and payment exists with status of Success', (done) => {
+            authoriseStub.returns(Promise.resolve({name: 'Success'}));
+            findPaymentStub.returns(Promise.resolve(successfulPaymentResponse));
+            sendToSubmitServiceStub.returns(submitResponse);
+            const PaymentBreakdown = steps.PaymentBreakdown;
+            const hostname = 'localhost';
+            const ctxTestData = {total: 215};
+            const errorsTestData = [];
+            const formdata = {
+                creatingPayment: 'true',
+                payment: {
+                    paymentId: 'RC-12345'
+                }
+            };
+            const session = {
+                save: () => true
+            };
+
+            co(function* () {
+                const [ctx, errors] = yield PaymentBreakdown.handlePost(ctxTestData,
+                    errorsTestData, formdata, session, hostname);
+                assert.deepEqual(formdata, {
+                    'ccdCase': {
+                        'id': 1535395401245028,
+                        'state': 'PaAppCreated'
+                    },
+                    'creatingPayment': 'true',
+                    'payment': {
+                        'total': 215,
+                        "paymentId": "RC-12345"
+                    },
+                    'paymentPending': 'true',
+                    'registry': {
+                        'registry': {
+                            'address': 'Line 1 Ox\nLine 2 Ox\nLine 3 Ox\nPostCode Ox\n',
+                            'email': 'oxford@email.com',
+                            'name': 'Oxford',
+                            'sequenceNumber': 10034
+                        },
+                        'submissionReference': 97
+                    },
+                    'submissionReference': 97
+                });
+                assert.deepEqual(ctx, ctxTestData);
+                assert.equal(errors, errorsTestData);
+                done();
+            })
+                .catch((err) => {
+                    done(err);
+                });
+        });
+
+        it('sets paymentPending to true if ctx.total > 0 and payment exists with status of Initiated', (done) => {
+            authoriseStub.returns(Promise.resolve({name: 'Success'}));
+            findPaymentStub.returns(Promise.resolve(initiatedPaymentResponse));
+            sendToSubmitServiceStub.returns(submitResponse);
+            const PaymentBreakdown = steps.PaymentBreakdown;
+            const hostname = 'localhost';
+            const ctxTestData = {total: 215};
+            const errorsTestData = [];
+            const formdata = {
+                creatingPayment: 'true',
+                payment: {
+                    paymentId: 'RC-12345'
+                }
+            };
+            const session = {
+                save: () => true
+            };
+
+            co(function* () {
+                const [ctx, errors] = yield PaymentBreakdown.handlePost(ctxTestData,
+                    errorsTestData, formdata, session, hostname);
+                assert.deepEqual(formdata, {
+                    'ccdCase': {
+                        'id': 1535395401245028,
+                        'state': 'PaAppCreated'
+                    },
+                    'creatingPayment': 'true',
+                    'payment': {
+                        'total': 215,
+                        "paymentId": "RC-12345"
+                    },
+                    'paymentPending': 'true',
+                    'registry': {
+                        'registry': {
+                            'address': 'Line 1 Ox\nLine 2 Ox\nLine 3 Ox\nPostCode Ox\n',
+                            'email': 'oxford@email.com',
+                            'name': 'Oxford',
+                            'sequenceNumber': 10034
+                        },
+                        'submissionReference': 97
+                    },
+                    'submissionReference': 97
+                });
+                assert.deepEqual(ctx, ctxTestData);
+                assert.equal(errors, errorsTestData);
                 done();
             })
                 .catch((err) => {

--- a/test/unit/testPaymentStatus.js
+++ b/test/unit/testPaymentStatus.js
@@ -21,6 +21,17 @@ describe('PaymentStatus', () => {
         'external_reference': 12345
     };
 
+    const initiatedPaymentResponse = {
+        'channel': 'Online',
+        'id': 12345,
+        'reference': 'PaymentReference12345',
+        'amount': 5000,
+        'status': 'Initiated',
+        'date_updated': '2018-08-29T15:25:11.920+0000',
+        'site_id': 'siteId0001',
+        'external_reference': 12345
+    };
+
     const failedPaymentResponse = {
         'channel': 'Online',
         'id': 12345,
@@ -223,6 +234,44 @@ describe('PaymentStatus', () => {
                 done(err);
             });
         }));
+
+        it('should set redirect to true, paymentPending to true and payment status to success if payment is successful with no case created',
+            sinon.test((done) => {
+                const expectedFormData = {
+                    'paymentPending': 'true',
+                    'payment': {
+                        'amount': 5000,
+                        'channel': 'Online',
+                        'date': '2018-08-29T15:25:11.920+0000',
+                        'reference': 'PaymentReference12345',
+                        'siteId': 'siteId0001',
+                        'status': 'Initiated',
+                        'transactionId': 12345
+                    }
+                };
+                servicesMock.expects('authorise').returns(Promise.resolve({}));
+                servicesMock.expects('findPayment').returns(
+                    Promise.resolve(initiatedPaymentResponse));
+                servicesMock.expects('updateCcdCasePaymentStatus').returns(
+                    Promise.resolve({'caseState': 'caseCreated'}));
+                const ctx = {
+                    authToken: 'XXXXX',
+                    userId: 12345,
+                    paymentId: 4567
+                };
+                const formData = {paymentPending: 'true', 'payment': {}};
+                co(function* () {
+                    const options = yield PaymentStatus.runnerOptions(ctx, formData);
+                    assert.deepEqual(options.redirect, true);
+                    assert.deepEqual(formData, expectedFormData);
+                    servicesMock.expects('findPayment').never();
+                    servicesMock.expects('authorise').never();
+                    servicesMock.expects('updateCcdCasePaymentStatus').never();
+                    done();
+                }).catch(err => {
+                    done(err);
+                });
+            }));
     });
 
 });


### PR DESCRIPTION
### Change description ###
- Stop a payment being created when status of the payment is already "Success" or "Initiated".
- Stop case status being updated to failed, when payment response status is "Initiated".

The above stops duplicates and handles payments with "Initiated" status better.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
