### PR TITLE
[PREVIEW] PRO-3790: Fix to allow case to be updated after submit service is down.

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -52,7 +52,7 @@ router.use((req, res, next) => {
     const executorsWrapper = new ExecutorsWrapper(formdata.executors);
     const hasMultipleApplicants = executorsWrapper.hasMultipleApplicants();
 
-    if (get(formdata, 'submissionReference') && (get(formdata, 'payment.status') === 'Success' || get(formdata, 'payment.status') === 'not_required') &&
+    if (get(formdata, 'submissionReference') && get(formdata, 'ccdCase.state') === 'CaseCreated' && (get(formdata, 'payment.status') === 'Success' || get(formdata, 'payment.status') === 'not_required') &&
         !includes(config.whitelistedPagesAfterSubmission, req.originalUrl)
     ) {
         res.redirect('documents');

--- a/test/component/payment/testPaymentStatus.js
+++ b/test/component/payment/testPaymentStatus.js
@@ -17,7 +17,7 @@ describe('payment-status', () => {
         testWrapper = new TestWrapper('PaymentStatus');
 
         nock(SUBMIT_SERVICE_URL).post('/updatePaymentStatus')
-            .reply(200, {});
+            .reply(200, {caseState: 'CreatedCase'});
         nock(`${CREATE_PAYMENT_SERVICE_URL.replace('userId', USER_ID)}`).get('/1')
             .reply(200, {
                 'channel': 'Online',

--- a/test/component/testRedirectToDocuments.js
+++ b/test/component/testRedirectToDocuments.js
@@ -10,6 +10,10 @@ describe('redirect to documents', () => {
     beforeEach(() => {
         testWrapper = new TestWrapper('CopiesUk');
         sessionData = {
+            'ccdCase': {
+                'state': 'CaseCreated',
+                'id': 1535395401245028
+            },
             'submissionReference': 'testSubmissionReference',
             'payment': {
                 'status': 'Success'

--- a/test/data/complete-form.json
+++ b/test/data/complete-form.json
@@ -1,5 +1,9 @@
 {
   "formdata": {
+    "ccdCase": {
+      "state": "CaseCreated",
+      "id": 1535395401245028
+    },
     "payloadVersion": "1.0",
     "will": {
       "left": "Yes",

--- a/test/unit/testPaymentStatus.js
+++ b/test/unit/testPaymentStatus.js
@@ -75,7 +75,7 @@ describe('PaymentStatus', () => {
             sinon.test((done) => {
                 const expectedFormData = {
                     'ccdCase': {
-                        'state': 'caseCreated'
+                        'state': 'CaseCreated'
                     },
                     'paymentPending': 'false',
                     'payment': {
@@ -92,7 +92,7 @@ describe('PaymentStatus', () => {
                 servicesMock.expects('findPayment').returns(
                     Promise.resolve(successfulPaymentResponse));
                 servicesMock.expects('updateCcdCasePaymentStatus').returns(
-                    Promise.resolve({'caseState': 'caseCreated'}));
+                    Promise.resolve({'caseState': 'CaseCreated'}));
                 const ctx = {
                     authToken: 'XXXXX',
                     userId: 12345,
@@ -116,7 +116,7 @@ describe('PaymentStatus', () => {
             sinon.test((done) => {
                 const expectedFormData = {
                     'ccdCase': {
-                        'state': 'caseCreated'
+                        'state': 'CaseCreated'
                     },
                     'paymentPending': 'true',
                     'payment': {
@@ -133,7 +133,7 @@ describe('PaymentStatus', () => {
                 servicesMock.expects('findPayment').returns(
                     Promise.resolve(failedPaymentResponse));
                 servicesMock.expects('updateCcdCasePaymentStatus').returns(
-                    Promise.resolve({'caseState': 'caseCreated'}));
+                    Promise.resolve({'caseState': 'CaseCreated'}));
 
                 const ctx = {
                     authToken: 'XXXXX',

--- a/test/unit/testTasklist.js
+++ b/test/unit/testTasklist.js
@@ -242,6 +242,10 @@ describe('Tasklist', () => {
 
         it('Updates the context: PaymentTask complete', () => {
             req.session.form = {
+                ccdCase: {
+                    state: 'CaseCreated',
+                    id: 1535395401245028
+                },
                 paymentPending: 'false',
                 payment: {
                     status: 'Success'


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PRO-3790

### Change description ###
Update to the payment-status page to detect the state of the CCD payment update and to show an error if caseState does not match 'CaseCreated'. The logic for this is as follows.
1. Check we have a valid payment response if so then...
2. Check we have a valid ccd update response if so then confirm response is 'CaseCreated'.
3. Update case status in formdata.
4. If either payment response or ccd update response is not valid then stay on payment-status and show error, otherwise move to documents page.

I've also updated the routes.js to properly detect the conditions for being on the documents page which was missing the state of the ccd update matching 'CaseCreated'.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
