### PR TITLE
PRO-4040: Fixed deceased alias always cleared by post handler

### DIFF
--- a/app/steps/ui/deceased/alias/index.js
+++ b/app/steps/ui/deceased/alias/index.js
@@ -27,7 +27,7 @@ class DeceasedAlias extends ValidationStep {
     }
 
     handlePost(ctx, errors) {
-        const hasAlias = (new DeceasedWrapper(ctx.deceased)).hasAlias();
+        const hasAlias = (new DeceasedWrapper(ctx)).hasAlias();
         if (!hasAlias) {
             delete ctx.otherNames;
         }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PRO-4040


### Change description ###
Fixing the `handlePost()` method in `DeceasedAlias` which doesn't pass the correct parameter into `Deceased` wrapper, such that `hasAlias` is always true


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
