### PR TITLE
PRO-4273 - Doc Upload: Documents section should still be present on CYA even if no Doc uploaded

### DIFF
--- a/app/resources/en/translation/summary.json
+++ b/app/resources/en/translation/summary.json
@@ -5,6 +5,7 @@
   "willHeading": "The will",
   "willWithCodicilHeading": "The will and codicils",
   "uploadedDocumentsHeading": "Uploaded documents",
+  "uploadedDocumentsEmpty": "No documents have been uploaded",
   "applicantHeading": "The executors",
   "deceasedHeading": "About the person who died",
   "ihtHeading": "Inheritance tax",

--- a/app/steps/ui/summary/includes/documentupload.njk
+++ b/app/steps/ui/summary/includes/documentupload.njk
@@ -1,4 +1,4 @@
-{% if fields.summary.uploadedDocuments.value | length > 0 %}
+{% if fields.summary.uploadedDocuments.value | length > 0 and fields.summary.isDocumentUploadToggleEnabled.value === "true" %}
 {{checkanswer(
     items = [{
             question: content.DocumentUpload.deathCertificate,

--- a/app/steps/ui/summary/includes/documentupload.njk
+++ b/app/steps/ui/summary/includes/documentupload.njk
@@ -1,14 +1,15 @@
-{% if fields.summary.uploadedDocuments.value | length > 0 and fields.summary.isDocumentUploadToggleEnabled.value === "true" %}
+{% set isUploadedDocuments = fields.summary.uploadedDocuments.value | length > 0 %}
 {{checkanswer(
     items = [{
             question: content.DocumentUpload.deathCertificate,
-            answer: fields.summary.uploadedDocuments.value,
-            visible: fields.summary.uploadedDocuments.value
+            answer: fields.summary.uploadedDocuments.value if isUploadedDocuments else content.Summary.uploadedDocumentsEmpty,
+            visible: true
         }
     ],
     url = content.DocumentUpload.url,
     common = common,
     alreadyDeclared = fields.summary.alreadyDeclared.value,
-    answerIsCollection = true
+    answerIsCollection = isUploadedDocuments,
+    answerIsGroup = false,
+    isComplete = true if isUploadedDocuments else false
 )}}
-{% endif %}

--- a/app/steps/ui/summary/includes/documentupload.njk
+++ b/app/steps/ui/summary/includes/documentupload.njk
@@ -1,3 +1,4 @@
+{% if fields.summary.uploadedDocuments.value | length > 0 %}
 {{checkanswer(
     items = [{
             question: content.DocumentUpload.deathCertificate,
@@ -10,3 +11,4 @@
     alreadyDeclared = fields.summary.alreadyDeclared.value,
     answerIsCollection = true
 )}}
+{% endif %}

--- a/app/steps/ui/summary/template.html
+++ b/app/steps/ui/summary/template.html
@@ -21,7 +21,7 @@
             {% include "ui/summary/includes/deceased.njk" %}
         </dl>
 
-        {% ifAsync fields.summary.uploadedDocuments.value | length > 0 and fields.summary.isDocumentUploadToggleEnabled.value === "true" %}
+        {% ifAsync fields.summary.isDocumentUploadToggleEnabled.value === "true" %}
             <h2 class="heading-medium">{{content.Summary.uploadedDocumentsHeading}}</h2>
             <dl class="check-your-answers check-your-answers--long">
                 {% include "ui/summary/includes/documentupload.njk" %}
@@ -42,7 +42,7 @@
             {% include "ui/summary/includes/will.njk" %}
         </dl>
 
-        {% ifAsync fields.summary.uploadedDocuments.value | length > 0 and fields.summary.isDocumentUploadToggleEnabled.value === "true" %}
+        {% ifAsync fields.summary.isDocumentUploadToggleEnabled.value === "true" %}
             <h2 class="heading-medium">{{content.Summary.uploadedDocumentsHeading}}</h2>
             <dl class="check-your-answers check-your-answers--long">
                 {% include "ui/summary/includes/documentupload.njk" %}

--- a/app/views/widgets/checkanswer.html
+++ b/app/views/widgets/checkanswer.html
@@ -1,12 +1,11 @@
-{% macro checkanswer(items, url, common, alreadyDeclared, answerIsCollection, answerIsGroup) %}
+{% macro checkanswer(items, url, common, alreadyDeclared, answerIsCollection, answerIsGroup, isComplete) %}
 
 {%  set anyVisibleItems = items | selectattr("visible") | length %}
 {% if anyVisibleItems %}
 
-    {% set complete = false  %}
     {% for item in items %}
     {% if item.visible %}
-    {% if item.answer%}{% set complete = true  %}{% endif %}
+    {% set complete = true if isComplete !== false and item.answer else false %}
         <div class="check-your-answers__row">
             <dt class="check-your-answers__question">{{item.question | safe}}</dt>
             {% if answerIsCollection %}

--- a/test/component/summary/testDocumentUploadSection.js
+++ b/test/component/summary/testDocumentUploadSection.js
@@ -31,8 +31,7 @@ describe('summary-documentupload-section', () => {
                 .get(featureTogglePathDocument)
                 .reply(200, 'false');
 
-            const playbackData = {
-            };
+            const playbackData = [];
             testWrapper.testDataPlayback(done, playbackData);
         });
 
@@ -68,8 +67,11 @@ describe('summary-documentupload-section', () => {
                     if (err) {
                         throw err;
                     }
-                    const playbackData = {
-                    };
+                    const playbackData = [
+                        summaryContent.uploadedDocumentsHeading,
+                        documentuploadContent.deathCertificate,
+                        summaryContent.uploadedDocumentsEmpty
+                    ];
                     testWrapper.testDataPlayback(done, playbackData);
                 });
         });
@@ -112,6 +114,9 @@ describe('summary-documentupload-section', () => {
                         throw err;
                     }
                     const playbackData = [
+                        summaryContent.uploadedDocumentsHeading,
+                        documentuploadContent.deathCertificate,
+                        summaryContent.uploadedDocumentsEmpty
                     ];
                     testWrapper.testDataPlayback(done, playbackData);
                 });

--- a/test/component/summary/testSummary.js
+++ b/test/component/summary/testSummary.js
@@ -41,7 +41,8 @@ describe('summary', () => {
                 'address',
                 'mobileNumber',
                 'emailAddress',
-                'uploadedDocumentsHeading'
+                'uploadedDocumentsHeading',
+                'uploadedDocumentsEmpty'
             ];
             testWrapper.testContent(done, contentToExclude);
         });
@@ -64,7 +65,8 @@ describe('summary', () => {
                 'currentNameReason',
                 'mobileNumber',
                 'emailAddress',
-                'uploadedDocumentsHeading'
+                'uploadedDocumentsHeading',
+                'uploadedDocumentsEmpty'
             ];
             testWrapper.testContent(done, contentToExclude);
         });


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/PRO-4273

### Change description ###

Display the uploaded documents section on the summary page with a default message when no documents have been uploaded so it gives the user a chance to return to the document upload page to add upload documents.

![screenshot_2018-12-03 summary page - apply for probate 1](https://user-images.githubusercontent.com/6839214/49391876-c45b4800-f724-11e8-823d-388a5848879b.png)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```