### PR TITLE
PRO-4264: Dealing with estate prune formdata

### DIFF
--- a/app/resources/en/translation/payment/breakdown.json
+++ b/app/resources/en/translation/payment/breakdown.json
@@ -8,17 +8,17 @@
   "errors": {
     "authorisation": {
       "failure": {
-        "summary": "auth failure - We could not take your payment, please try again later"
+        "summary": "We could not take your payment, please try again later"
       }
     },
     "payment": {
       "failure": {
-        "summary": "payment failure - We could not take your payment, please try again later"
+        "summary": "We could not take your payment, please try again later"
       }
     },
     "submit": {
       "failure": {
-        "summary": "submit failure - We could not take your payment, please try again later"
+        "summary": "We could not take your payment, please try again later"
       },
       "duplicate": {
         "summary": "Your application has been submitted, please return to the tasklist to continue"

--- a/app/resources/en/translation/payment/breakdown.json
+++ b/app/resources/en/translation/payment/breakdown.json
@@ -8,17 +8,17 @@
   "errors": {
     "authorisation": {
       "failure": {
-        "summary": "We could not take your payment, please try again later"
+        "summary": "auth failure - We could not take your payment, please try again later"
       }
     },
     "payment": {
       "failure": {
-        "summary": "We could not take your payment, please try again later"
+        "summary": "payment failure - We could not take your payment, please try again later"
       }
     },
     "submit": {
       "failure": {
-        "summary": "We could not take your payment, please try again later"
+        "summary": "submit failure - We could not take your payment, please try again later"
       },
       "duplicate": {
         "summary": "Your application has been submitted, please return to the tasklist to continue"

--- a/app/steps/ui/executors/additionalinvite/index.js
+++ b/app/steps/ui/executors/additionalinvite/index.js
@@ -13,6 +13,7 @@ class ExecutorsAdditionalInvite extends ValidationStep {
 
     getContextData(req) {
         const ctx = super.getContextData(req);
+        ctx.executorsToNotifyList = new ExecutorsWrapper(ctx).executorsToNotify();
         ctx.inviteSuffix = size(ctx.executorsToNotifyList) > 1 ? '-multiple' : '';
         ctx.executorsToNotifyNames = FormatName.formatExecutorNames(ctx.executorsToNotifyList);
         return ctx;

--- a/app/steps/ui/executors/additionalinvite/template.html
+++ b/app/steps/ui/executors/additionalinvite/template.html
@@ -13,26 +13,47 @@
 
     <h2 class="heading-medium">{{ content.heading1 | safe }}</h2>
 
-    {% for executor in fields.executorsToNotifyList.value %}
-        <div class="grid-row word-wrap">
-            <div class="column-one-quarter">
-                <p>{{ executor.fullName }}</p>
-            </div>
+    <!--{% for executor in fields.executorsToNotifyList.value %}-->
+        <!--<div class="grid-row word-wrap">-->
+            <!--<div class="column-one-quarter">-->
+                <!--<p>{{ executor.fullName }}</p>-->
+            <!--</div>-->
 
-            <div class="column-one-quarter">
-                <p>{{ executor.email }}</p>
-            </div>
+            <!--<div class="column-one-quarter">-->
+                <!--<p>{{ executor.email }}</p>-->
+            <!--</div>-->
 
-            <div class="column-one-quarter">
-                <p>{{ executor.mobile }}</p>
-            </div>
+            <!--<div class="column-one-quarter">-->
+                <!--<p>{{ executor.mobile }}</p>-->
+            <!--</div>-->
 
-            <div class="column-one-quarter">
-                <p>
-                    <a href="/executor-contact-details/{{ loop.index0 }}">{{ content.changeLink }}</a>
-                </p>
-            </div>
+            <!--<div class="column-one-quarter">-->
+                <!--<p>-->
+                    <!--<a href="/executor-contact-details/{{ loop.index0 }}">{{ content.changeLink }}</a>-->
+                <!--</p>-->
+            <!--</div>-->
+        <!--</div>-->
+    <!--{% endfor %}-->
+
+    {% for executor in fields.list.value %}
+    {% if executor.isApplicant !== true and executor.isApplying and executor.emailSent !== true %}
+    <div class="grid-row word-wrap">
+        <div class="column-one-quarter">
+            <p>{{ executor.fullName }}</p>
         </div>
+        <div class="column-one-quarter">
+            <p>{{ executor.email }}</p>
+        </div>
+        <div class="column-one-quarter">
+            <p>{{ executor.mobile }}</p>
+        </div>
+        <div class="column-one-quarter">
+            <p>
+                <a href="/executor-contact-details/{{ loop.index - 1 }}">{{ content.changeLink }}</a>
+            </p>
+        </div>
+    </div>
+    {% endif %}
     {% endfor %}
 
     <div class="form-group">

--- a/app/steps/ui/executors/additionalinvite/template.html
+++ b/app/steps/ui/executors/additionalinvite/template.html
@@ -13,28 +13,6 @@
 
     <h2 class="heading-medium">{{ content.heading1 | safe }}</h2>
 
-    <!--{% for executor in fields.executorsToNotifyList.value %}-->
-        <!--<div class="grid-row word-wrap">-->
-            <!--<div class="column-one-quarter">-->
-                <!--<p>{{ executor.fullName }}</p>-->
-            <!--</div>-->
-
-            <!--<div class="column-one-quarter">-->
-                <!--<p>{{ executor.email }}</p>-->
-            <!--</div>-->
-
-            <!--<div class="column-one-quarter">-->
-                <!--<p>{{ executor.mobile }}</p>-->
-            <!--</div>-->
-
-            <!--<div class="column-one-quarter">-->
-                <!--<p>-->
-                    <!--<a href="/executor-contact-details/{{ loop.index0 }}">{{ content.changeLink }}</a>-->
-                <!--</p>-->
-            <!--</div>-->
-        <!--</div>-->
-    <!--{% endfor %}-->
-
     {% for executor in fields.list.value %}
     {% if executor.isApplicant !== true and executor.isApplying and executor.emailSent !== true %}
     <div class="grid-row word-wrap">

--- a/app/steps/ui/executors/address/index.js
+++ b/app/steps/ui/executors/address/index.js
@@ -90,6 +90,7 @@ class ExecutorAddress extends AddressStep {
         delete ctx.continue;
         delete ctx.index;
         delete ctx.executorsWrapper;
+        delete ctx.addressFound;
         return [ctx, formdata];
     }
 

--- a/app/steps/ui/executors/contactdetails/index.js
+++ b/app/steps/ui/executors/contactdetails/index.js
@@ -3,6 +3,7 @@
 const ValidationStep = require('app/core/steps/ValidationStep');
 const emailValidator = require('email-validator');
 const validator = require('validator');
+const ExecutorsWrapper = require('app/wrappers/Executors');
 const FieldError = require('app/components/error');
 const {findIndex, every, tail} = require('lodash');
 const InviteData = require('app/services/InviteData');

--- a/app/steps/ui/executors/contactdetails/index.js
+++ b/app/steps/ui/executors/contactdetails/index.js
@@ -5,7 +5,6 @@ const emailValidator = require('email-validator');
 const validator = require('validator');
 const FieldError = require('app/components/error');
 const {findIndex, every, tail} = require('lodash');
-const ExecutorsWrapper = require('app/wrappers/Executors');
 const InviteData = require('app/services/InviteData');
 const config = require('app/config');
 
@@ -36,7 +35,6 @@ class ExecutorContactDetails extends ValidationStep {
     }
 
     * handlePost(ctx, errors) {
-        //const executorsWrapper = new ExecutorsWrapper(ctx);
         const executor = ctx.list[ctx.index];
         if (!emailValidator.validate(ctx.email)) {
             errors.push(FieldError('email', 'invalid', this.resourcePath, this.generateContent()));
@@ -50,7 +48,6 @@ class ExecutorContactDetails extends ValidationStep {
             executor.emailChanged = true;
         }
 
-        // ctx.executorsEmailChanged = executorsWrapper.hasExecutorsEmailChanged();
         executor.email = ctx.email;
         executor.mobile = ctx.mobile;
         if (executor.emailSent) {

--- a/app/steps/ui/executors/contactdetails/index.js
+++ b/app/steps/ui/executors/contactdetails/index.js
@@ -36,7 +36,7 @@ class ExecutorContactDetails extends ValidationStep {
     }
 
     * handlePost(ctx, errors) {
-        const executorsWrapper = new ExecutorsWrapper(ctx);
+        //const executorsWrapper = new ExecutorsWrapper(ctx);
         const executor = ctx.list[ctx.index];
         if (!emailValidator.validate(ctx.email)) {
             errors.push(FieldError('email', 'invalid', this.resourcePath, this.generateContent()));
@@ -50,7 +50,7 @@ class ExecutorContactDetails extends ValidationStep {
             executor.emailChanged = true;
         }
 
-        ctx.executorsEmailChanged = executorsWrapper.hasExecutorsEmailChanged();
+        // ctx.executorsEmailChanged = executorsWrapper.hasExecutorsEmailChanged();
         executor.email = ctx.email;
         executor.mobile = ctx.mobile;
         if (executor.emailSent) {

--- a/app/steps/ui/executors/contactdetails/index.js
+++ b/app/steps/ui/executors/contactdetails/index.js
@@ -35,6 +35,7 @@ class ExecutorContactDetails extends ValidationStep {
     }
 
     * handlePost(ctx, errors) {
+        const executorsWrapper = new ExecutorsWrapper(ctx);
         const executor = ctx.list[ctx.index];
         if (!emailValidator.validate(ctx.email)) {
             errors.push(FieldError('email', 'invalid', this.resourcePath, this.generateContent()));
@@ -48,6 +49,7 @@ class ExecutorContactDetails extends ValidationStep {
             executor.emailChanged = true;
         }
 
+        ctx.executorsEmailChanged = executorsWrapper.hasExecutorsEmailChanged();
         executor.email = ctx.email;
         executor.mobile = ctx.mobile;
         if (executor.emailSent) {

--- a/app/steps/ui/executors/contactdetails/index.js
+++ b/app/steps/ui/executors/contactdetails/index.js
@@ -50,7 +50,6 @@ class ExecutorContactDetails extends ValidationStep {
             executor.emailChanged = true;
         }
 
-        ctx.executorsToNotifyList = executorsWrapper.executorsToNotify();
         ctx.executorsEmailChanged = executorsWrapper.hasExecutorsEmailChanged();
         executor.email = ctx.email;
         executor.mobile = ctx.mobile;

--- a/app/steps/ui/executors/dealingwithestate/index.js
+++ b/app/steps/ui/executors/dealingwithestate/index.js
@@ -26,7 +26,7 @@ class ExecutorsDealingWithEstate extends ValidationStep {
         return ctx;
     }
 
-    pruneFormData(data) {
+    pruneExecutorData(data) {
         if (data.isApplying) {
             delete data.isDead;
             delete data.diedBefore;
@@ -50,7 +50,7 @@ class ExecutorsDealingWithEstate extends ValidationStep {
     handlePost(ctx, errors) {
         for (let i = 1; i < ctx.executorsNumber; i++) {
             ctx.list[i].isApplying = includes(ctx.executorsApplying, ctx.list[i].fullName);
-            ctx.list[i] = this.pruneFormData(ctx.list[i]);
+            ctx.list[i] = this.pruneExecutorData(ctx.list[i]);
         }
         return [ctx, errors];
     }

--- a/app/steps/ui/executors/dealingwithestate/index.js
+++ b/app/steps/ui/executors/dealingwithestate/index.js
@@ -34,6 +34,15 @@ class ExecutorsDealingWithEstate extends ValidationStep {
             delete data.notApplyingKey;
         } else {
             delete data.isApplying;
+            delete data.address;
+            delete data.currentName;
+            delete data.currentNameReason;
+            delete data.email;
+            delete data.freeTextAddress;
+            delete data.hasOtherName;
+            delete data.mobile;
+            delete data.postcode;
+            delete data.postcodeAddress;
         }
         return data;
     }

--- a/app/steps/ui/executors/roles/index.js
+++ b/app/steps/ui/executors/roles/index.js
@@ -26,6 +26,7 @@ class ExecutorRoles extends CollectionStep {
 
     handlePost(ctx, errors) {
         if (ctx.list[ctx.index]) {
+            ctx.list[ctx.index] = this.pruneExecutorData(ctx.list[ctx.index]);
             ctx.list[ctx.index].isApplying = false;
             ctx.list[ctx.index].notApplyingReason = ctx.notApplyingReason;
             ctx.list[ctx.index].notApplyingKey = findKey(json, o => o === ctx.notApplyingReason);
@@ -34,6 +35,19 @@ class ExecutorRoles extends CollectionStep {
             ctx.index = this.recalcIndex(ctx, ctx.index);
         }
         return [ctx, errors];
+    }
+
+    pruneExecutorData(data) {
+        delete data.address;
+        delete data.currentName;
+        delete data.currentNameReason;
+        delete data.email;
+        delete data.freeTextAddress;
+        delete data.hasOtherName;
+        delete data.mobile;
+        delete data.postcode;
+        delete data.postcodeAddress;
+        return data;
     }
 
     isComplete(ctx) {

--- a/app/steps/ui/payment/breakdown/index.js
+++ b/app/steps/ui/payment/breakdown/index.js
@@ -77,7 +77,7 @@ class PaymentBreakdown extends Step {
             const [result, submissionErrors] = yield this.sendToSubmitService(ctx, errors, formdata, ctx.total);
             errors = errors.concat(submissionErrors);
             if (errors.length > 0) {
-                logger.error('Failed to create case in CCD.');
+                logger.error('Failed to create case in CCD.', errors);
                 return [ctx, errors];
             }
             formdata.submissionReference = result.submissionReference;

--- a/test/component/executors/testExecutorsAdditionalInvite.js
+++ b/test/component/executors/testExecutorsAdditionalInvite.js
@@ -48,7 +48,7 @@ describe('executors-additional-invite', () => {
         });
 
         it('test content displays only the executors who have been added and need to be emailed', (done) => {
-            sessionData.executors.executorsToNotifyList = [
+            sessionData.executors.list = [
                 {fullName: 'Andrew Wiles', isApplying: true, emailSent: false},
                 {fullName: 'Leonhard Euler', isApplying: true, emailSent: false}
             ];

--- a/test/component/executors/testExecutorsAdditionalInvite.js
+++ b/test/component/executors/testExecutorsAdditionalInvite.js
@@ -25,8 +25,9 @@ describe('executors-additional-invite', () => {
     describe('Verify Content, Errors and Redirection', () => {
 
         it('test correct content loaded on the page when only 1 other executor has been added and needs to be emailed', (done) => {
-            sessionData.executors.executorsToNotifyList = [
-                {fullName: 'Andrew Wiles', isApplying: true, emailSent: false},
+            sessionData.executors.list = [
+                {fullName: 'Applicant', isApplying: true, isApplicant: true},
+                {fullName: 'Andrew Wiles', isApplying: true, emailSent: false}
             ];
             testWrapper.agent.post('/prepare-session/form')
                 .send(sessionData)
@@ -36,7 +37,8 @@ describe('executors-additional-invite', () => {
         });
 
         it('test correct content loaded on the page when more than 1 other executor has been added and needs to be emailed', (done) => {
-            sessionData.executors.executorsToNotifyList = [
+            sessionData.executors.list = [
+                {fullName: 'Applicant', isApplying: true, isApplicant: true},
                 {fullName: 'Andrew Wiles', isApplying: true, emailSent: false},
                 {fullName: 'Leonhard Euler', isApplying: true, emailSent: false}
             ];
@@ -49,6 +51,7 @@ describe('executors-additional-invite', () => {
 
         it('test content displays only the executors who have been added and need to be emailed', (done) => {
             sessionData.executors.list = [
+                {fullName: 'Applicant', isApplying: true, isApplicant: true},
                 {fullName: 'Andrew Wiles', isApplying: true, emailSent: false},
                 {fullName: 'Leonhard Euler', isApplying: true, emailSent: false}
             ];
@@ -65,8 +68,10 @@ describe('executors-additional-invite', () => {
         });
 
         it('test content displays only the single executor who has had their email changed', (done) => {
-            sessionData.executors.executorsToNotifyList = [
+            sessionData.executors.list = [
+                {fullName: 'Applicant', isApplying: true, isApplicant: true},
                 {fullName: 'Andrew Wiles', isApplying: true, emailSent: false},
+                {fullName: 'Leonhard Euler', isApplying: true, emailSent: true}
             ];
             testWrapper.agent.post('/prepare-session/form')
                 .send(sessionData)
@@ -105,8 +110,9 @@ describe('executors-additional-invite', () => {
                 .reply(200, {response: 'Make it pass!'});
 
             const data = {};
-            sessionData.executors.executorsToNotifyList = [
-                {fullName: 'Andrew Wiles', isApplying: true, emailSent: false},
+            sessionData.executors.list = [
+                {fullName: 'Applicant', isApplying: true, isApplicant: true},
+                {fullName: 'Andrew Wiles', isApplying: true, emailSent: false}
             ];
             testWrapper.agent.post('/prepare-session/form')
                 .send(sessionData)

--- a/test/component/executors/testExecutorsInvite.js
+++ b/test/component/executors/testExecutorsInvite.js
@@ -63,7 +63,15 @@ describe('executors-invite', () => {
                 .post('/invite')
                 .reply(200, {response: 'Make it pass!'});
 
-            const data = {'list': [{'firstName': 'Bob', 'lastName': 'Smith', 'isApplicant': true}]};
+            const data = {
+                list: [
+                    {
+                        firstName: 'Bob',
+                        lastName: 'Smith',
+                        isApplicant: true
+                    }
+                ]
+            };
 
             testWrapper.testRedirect(done, data, expectedNextUrlForExecInvites);
         });

--- a/test/unit/testExecutorRoles.js
+++ b/test/unit/testExecutorRoles.js
@@ -58,6 +58,77 @@ describe('ExecutorRoles', () => {
         });
     });
 
+    describe('pruneExecutorData', () => {
+
+        const ctx = {
+            'list': [
+                {
+                    'lastName': 'Applicant',
+                    'firstName': 'Main',
+                    'isApplying': true,
+                    'isApplicant': true
+                },
+                {
+                    'email': 'probate0@mailinator.com',
+                    'mobile': '07900123456',
+                    'address': 'Princes house address',
+                    'postcode': 'NW1 8SS',
+                    'fullName': 'Prince Rogers Nelson',
+                    'hasOtherName': true,
+                    'currentName': 'Prince',
+                    'isApplying': false,
+                    'notApplyingKey': 'optionRenunciated',
+                    'freeTextAddress': 'Princes house address',
+                    'postcodeAddress': 'Adam & Eve 81 Petty France London SW1H 9EX',
+                    'notApplyingReason': 'This executor doesn&rsquo;t want to apply now, and gives up the right to do so in the future (this is also known as renunciation, and the executor will need to fill in a form)',
+                    'currentNameReason': 'Divorce',
+
+                }
+            ]
+        };
+
+        it('removes email from executor list data', () => {
+            const data = ExecutorRoles.pruneExecutorData(ctx.list[1]);
+            assert.isUndefined(data.email);
+        });
+
+        it('removes mobile from executor list data', () => {
+            const data = ExecutorRoles.pruneExecutorData(ctx.list[1]);
+            assert.isUndefined(data.mobile);
+        });
+
+        it('removes address from executor list data', () => {
+            const data = ExecutorRoles.pruneExecutorData(ctx.list[1]);
+            assert.isUndefined(data.address);
+        });
+
+        it('removes postcode from executor list data', () => {
+            const data = ExecutorRoles.pruneExecutorData(ctx.list[1]);
+            assert.isUndefined(data.postcode);
+        });
+
+        it('removes currentName from executor list data', () => {
+            const data = ExecutorRoles.pruneExecutorData(ctx.list[1]);
+            assert.isUndefined(data.currentName);
+        });
+
+        it('removes hasOtherName from executor list data', () => {
+            const data = ExecutorRoles.pruneExecutorData(ctx.list[1]);
+            assert.isUndefined(data.hasOtherName);
+        });
+
+        it('removes postcodeAddress from executor list data', () => {
+            const data = ExecutorRoles.pruneExecutorData(ctx.list[1]);
+            assert.isUndefined(data.postcodeAddress);
+        });
+
+        it('removes currentNameReason from executor list data', () => {
+            const data = ExecutorRoles.pruneExecutorData(ctx.list[1]);
+            assert.isUndefined(data.currentNameReason);
+        });
+
+    });
+
     describe('isComplete()', () => {
         it('should return the correct step completion status when all executors are applying', (done) => {
             const ctx = {

--- a/test/unit/testExecutorsAdditionalInvite.js
+++ b/test/unit/testExecutorsAdditionalInvite.js
@@ -46,30 +46,18 @@ describe('Executor-Additional-Invite', function () {
 
         it('test that context variables are correctly populated for multiple executors to be notified', () => {
             req.session.form.executors = {
-                executorsToNotifyList: [
+                list: [
                     {fullName: 'other applicant', isApplying: true, emailSent: false},
                     {fullName: 'harvey', isApplying: true, emailSent: false}
                 ]
             };
             ctx = executorsAdditionalInvite.getContextData(req);
-            expect(ctx).to.deep.equal({
-                executorsToNotifyList: [
-                    {
-                        emailSent: false,
-                        fullName: 'other applicant',
-                        isApplying: true
-                    },
-                    {
-                        emailSent: false,
-                        fullName: 'harvey',
-                        isApplying: true
-                    }
-                ],
-                executorsToNotifyNames: 'other applicant and harvey',
-                inviteSuffix: '-multiple',
-                sessionID: 'dummy_sessionId',
-                journeyType: 'probate'
-            });
+            expect(ctx.executorsToNotifyNames).to.equal('other applicant and harvey');
+            expect(ctx.inviteSuffix).to.equal('-multiple');
+            expect(ctx.executorsToNotifyList).to.deep.equal([
+                {emailSent: false, fullName: 'other applicant', isApplying: true},
+                {emailSent: false, fullName: 'harvey', isApplying: true}
+            ]);
         });
     });
 

--- a/test/unit/testExecutorsAdditionalInvite.js
+++ b/test/unit/testExecutorsAdditionalInvite.js
@@ -15,7 +15,7 @@ describe('Executor-Additional-Invite', function () {
                 sessionID: 'dummy_sessionId',
                 session: {
                     form: {
-                        executors: {},
+                        executors: [],
                         journeyType: 'probate'
                     },
                     journeyType: 'probate'
@@ -26,6 +26,7 @@ describe('Executor-Additional-Invite', function () {
         it('test that context variables are correctly populated for single executor to be notified', () => {
             req.session.form.executors = {
                 list: [
+                    {fullName: 'Applicant', isApplying: true, isApplicant: true},
                     {fullName: 'harvey', isApplying: true, emailSent: false}]
             };
             ctx = executorsAdditionalInvite.getContextData(req);
@@ -39,6 +40,7 @@ describe('Executor-Additional-Invite', function () {
         it('test that context variables are correctly populated for multiple executors to be notified', () => {
             req.session.form.executors = {
                 list: [
+                    {fullName: 'Applicant', isApplying: true, isApplicant: true},
                     {fullName: 'other applicant', isApplying: true, emailSent: false},
                     {fullName: 'harvey', isApplying: true, emailSent: false}
                 ]

--- a/test/unit/testExecutorsAdditionalInvite.js
+++ b/test/unit/testExecutorsAdditionalInvite.js
@@ -25,23 +25,15 @@ describe('Executor-Additional-Invite', function () {
 
         it('test that context variables are correctly populated for single executor to be notified', () => {
             req.session.form.executors = {
-                executorsToNotifyList: [
+                list: [
                     {fullName: 'harvey', isApplying: true, emailSent: false}]
             };
             ctx = executorsAdditionalInvite.getContextData(req);
-            expect(ctx).to.deep.equal({
-                executorsToNotifyList: [
-                    {
-                        'emailSent': false,
-                        'fullName': 'harvey',
-                        'isApplying': true
-                    }
-                ],
-                executorsToNotifyNames: 'harvey',
-                inviteSuffix: '',
-                sessionID: 'dummy_sessionId',
-                journeyType: 'probate'
-            });
+            expect(ctx.executorsToNotifyNames).to.equal('harvey');
+            expect(ctx.inviteSuffix).to.equal('');
+            expect(ctx.executorsToNotifyList).to.deep.equal([
+                {emailSent: false, fullName: 'harvey', isApplying: true}
+            ]);
         });
 
         it('test that context variables are correctly populated for multiple executors to be notified', () => {

--- a/test/unit/testExecutorsContactDetails.js
+++ b/test/unit/testExecutorsContactDetails.js
@@ -63,7 +63,7 @@ describe('Contact-Details', function () {
             errors = [];
         });
 
-        it('test emailChanged flag is correctly set, executorToBeNotifiedList is correctly populated and contact details updated (single applicant)', (done) => {
+        it('test emailChanged flag is correctly set and contact details updated (single applicant)', (done) => {
             co(function* () {
                 ctx.list[1].inviteId = 'dummy_inviteId';
                 ctx.list[1].emailChanged = true;
@@ -71,16 +71,6 @@ describe('Contact-Details', function () {
                 [ctx, errors] = yield contactDetails.handlePost(ctx, errors, formdata);
                 expect(ctx).to.deep.equal({
                     executorsNumber: 3,
-                    executorsToNotifyList: [
-                        {
-                            email: 'newtestemail@gmail.com',
-                            fullName: 'Bob Cratchett',
-                            inviteId: 'dummy_inviteId',
-                            emailChanged: true,
-                            isApplying: true,
-                            mobile: '07321321321'
-                        }
-                    ],
                     list: [
                         {
                             firstName: 'Lead',
@@ -119,7 +109,7 @@ describe('Contact-Details', function () {
                 });
         });
 
-        it('test emailChanged flag is correctly set, executorToBeNotifiedList is populated and contact details updated', (done) => {
+        it('test emailChanged flag is correctly set and contact details updated', (done) => {
             ctx.list[1].emailSent = false;
             ctx.list[2].emailSent = true;
             ctx.list[2].inviteId = 'dummy_id';
@@ -128,15 +118,6 @@ describe('Contact-Details', function () {
                 [ctx, errors] = yield contactDetails.handlePost(ctx, errors, formdata);
                 expect(ctx).to.deep.equal({
                     executorsNumber: 3,
-                    executorsToNotifyList: [
-                        {
-                            email: 'newtestemail@gmail.com',
-                            emailSent: false,
-                            fullName: 'Bob Cratchett',
-                            isApplying: true,
-                            mobile: '07321321321'
-                        }
-                    ],
                     list: [
                         {
                             firstName: 'Lead',
@@ -191,7 +172,6 @@ describe('Contact-Details', function () {
                 [ctx, errors] = yield contactDetails.handlePost(ctx, errors, formdata);
                 expect(ctx).to.deep.equal({
                     executorsNumber: 3,
-                    executorsToNotifyList: [],
                     list: [
                         {
                             firstName: 'Lead',

--- a/test/unit/testExecutorsContactDetails.js
+++ b/test/unit/testExecutorsContactDetails.js
@@ -58,7 +58,6 @@ describe('Contact-Details', function () {
                 mobile: '07321321321',
                 index: 1,
                 otherExecName: 'Bob Cratchett',
-                executorsEmailChanged: false
             };
             errors = [];
         });
@@ -100,7 +99,6 @@ describe('Contact-Details', function () {
                     mobile: '07321321321',
                     index: 1,
                     otherExecName: 'Bob Cratchett',
-                    executorsEmailChanged: true
                 });
                 done();
             })
@@ -147,7 +145,6 @@ describe('Contact-Details', function () {
                     mobile: '07321321321',
                     index: 1,
                     otherExecName: 'Bob Cratchett',
-                    executorsEmailChanged: false
                 });
                 done();
             })
@@ -202,7 +199,6 @@ describe('Contact-Details', function () {
                     mobile: '07888888888',
                     index: 1,
                     otherExecName: 'Bob Cratchett',
-                    executorsEmailChanged: true
                 });
                 revert();
                 done();

--- a/test/unit/testExecutorsContactDetails.js
+++ b/test/unit/testExecutorsContactDetails.js
@@ -58,6 +58,7 @@ describe('Contact-Details', function () {
                 mobile: '07321321321',
                 index: 1,
                 otherExecName: 'Bob Cratchett',
+                executorsEmailChanged: false
             };
             errors = [];
         });
@@ -99,6 +100,7 @@ describe('Contact-Details', function () {
                     mobile: '07321321321',
                     index: 1,
                     otherExecName: 'Bob Cratchett',
+                    executorsEmailChanged: true
                 });
                 done();
             })
@@ -145,6 +147,7 @@ describe('Contact-Details', function () {
                     mobile: '07321321321',
                     index: 1,
                     otherExecName: 'Bob Cratchett',
+                    executorsEmailChanged: false
                 });
                 done();
             })
@@ -199,6 +202,7 @@ describe('Contact-Details', function () {
                     mobile: '07888888888',
                     index: 1,
                     otherExecName: 'Bob Cratchett',
+                    executorsEmailChanged: true
                 });
                 revert();
                 done();

--- a/test/unit/testExecutorsDealing.js
+++ b/test/unit/testExecutorsDealing.js
@@ -106,6 +106,74 @@ describe('Executors-Applying', function () {
                 isApplying: true
             });
         });
+
+        const ctx = {
+            'list': [
+                {
+                    'lastName': 'Applicant',
+                    'firstName': 'Main',
+                    'isApplying': true,
+                    'isApplicant': true
+                },
+                {
+                    'email': 'probate0@mailinator.com',
+                    'mobile': '07900123456',
+                    'address': 'Princes house address',
+                    'postcode': 'NW1 8SS',
+                    'fullName': 'Prince Rogers Nelson',
+                    'hasOtherName': true,
+                    'currentName': 'Prince',
+                    'isApplying': false,
+                    'notApplyingKey': 'optionRenunciated',
+                    'freeTextAddress': 'Princes house address',
+                    'postcodeAddress': 'Adam & Eve 81 Petty France London SW1H 9EX',
+                    'notApplyingReason': 'This executor doesn&rsquo;t want to apply now, and gives up the right to do so in the future (this is also known as renunciation, and the executor will need to fill in a form)',
+                    'currentNameReason': 'Divorce',
+
+                }
+            ]
+        };
+
+        it('removes email from data if isApplying is false', () => {
+            const data = ExecsDealing.pruneFormData(ctx.list[1]);
+            assert.isUndefined(data.email);
+        });
+
+        it('removes mobile from data if isApplying is false', () => {
+            const data = ExecsDealing.pruneFormData(ctx.list[1]);
+            assert.isUndefined(data.mobile);
+        });
+
+        it('removes address from data if isApplying is false', () => {
+            const data = ExecsDealing.pruneFormData(ctx.list[1]);
+            assert.isUndefined(data.address);
+        });
+
+        it('removes postcode from data if isApplying is false', () => {
+            const data = ExecsDealing.pruneFormData(ctx.list[1]);
+            assert.isUndefined(data.postcode);
+        });
+
+        it('removes currentName from data if isApplying is false', () => {
+            const data = ExecsDealing.pruneFormData(ctx.list[1]);
+            assert.isUndefined(data.currentName);
+        });
+
+        it('removes hasOtherName from data if isApplying is false', () => {
+            const data = ExecsDealing.pruneFormData(ctx.list[1]);
+            assert.isUndefined(data.hasOtherName);
+        });
+
+        it('removes postcodeAddress from data if isApplying is false', () => {
+            const data = ExecsDealing.pruneFormData(ctx.list[1]);
+            assert.isUndefined(data.postcodeAddress);
+        });
+
+        it('removes currentNameReason from data if isApplying is false', () => {
+            const data = ExecsDealing.pruneFormData(ctx.list[1]);
+            assert.isUndefined(data.currentNameReason);
+        });
+
     });
 
     describe('handlePost', () => {
@@ -117,16 +185,28 @@ describe('Executors-Applying', function () {
                         'firstName': 'applicant',
                         'isApplying': 'Yes',
                         'isApplicant': true
-                    }, {
+                    },
+                    {
                         fullName: 'Ed Brown',
                         address: '20 Green Street, London, L12 9LN'
-                    }, {
+                    },
+                    {
                         fullName: 'Dave Miller',
                         address: '102 Petty Street, London, L12 9LN'
+                    },
+                    {
+                        email: 'probate0@mailinator.com',
+                        mobile: '07900123456',
+                        address: 'cher address',
+                        fullName: 'Cher',
+                        isApplying: false,
+                        notApplyingKey: 'optionRenunciated',
+                        freeTextAddress: 'cher address',
+                        notApplyingReason: 'This executor doesn&rsquo;t want to apply now, and gives up the right to do so in the future (this is also known as renunciation, and the executor will need to fill in a form)'
                     }
                 ],
                 executorsApplying: ['Dave Miller'],
-                executorsNumber: 3
+                executorsNumber: 4
             };
         });
 
@@ -139,6 +219,20 @@ describe('Executors-Applying', function () {
         it('test executors (with checkbox checked) isApplying flag is set to true', () => {
             [ctx, errors] = ExecsDealing.handlePost(ctxTest);
             assert.isTrue(ctx.list[2].isApplying);
+            assert.isUndefined(errors);
+        });
+
+        it('should prune executor 3 data', () => {
+            [ctx, errors] = ExecsDealing.handlePost(ctxTest);
+            assert.isUndefined(ctx.list[3].isApplying);
+            assert.isUndefined(ctx.list[3].address);
+            assert.isUndefined(errors);
+        });
+
+        it('should not prune executor 2 data', () => {
+            [ctx, errors] = ExecsDealing.handlePost(ctxTest);
+            expect(ctx.list[2].isApplying).to.equal(true);
+            expect(ctx.list[2].address).to.equal('102 Petty Street, London, L12 9LN');
             assert.isUndefined(errors);
         });
     });

--- a/test/unit/testExecutorsDealing.js
+++ b/test/unit/testExecutorsDealing.js
@@ -79,14 +79,14 @@ describe('Executors-Applying', function () {
         });
     });
 
-    describe('pruneFormData', () => {
+    describe('pruneExecutorData', () => {
 
         it('test that isApplying flag is deleted when executor is not applying', () => {
             data = {
                 fullName: 'Ed Brown',
                 isApplying: false
             };
-            ExecsDealing.pruneFormData(data);
+            ExecsDealing.pruneExecutorData(data);
             assert.isUndefined(data.isApplying);
             expect(data).to.deep.equal({fullName: 'Ed Brown'});
         });
@@ -100,7 +100,7 @@ describe('Executors-Applying', function () {
                 notApplyingReason: 'not sure',
                 notApplyingKey: 'not sure'
             };
-            ExecsDealing.pruneFormData(data);
+            ExecsDealing.pruneExecutorData(data);
             expect(data).to.deep.equal({
                 fullName: 'Ed Brown',
                 isApplying: true
@@ -135,42 +135,42 @@ describe('Executors-Applying', function () {
         };
 
         it('removes email from data if isApplying is false', () => {
-            const data = ExecsDealing.pruneFormData(ctx.list[1]);
+            const data = ExecsDealing.pruneExecutorData(ctx.list[1]);
             assert.isUndefined(data.email);
         });
 
         it('removes mobile from data if isApplying is false', () => {
-            const data = ExecsDealing.pruneFormData(ctx.list[1]);
+            const data = ExecsDealing.pruneExecutorData(ctx.list[1]);
             assert.isUndefined(data.mobile);
         });
 
         it('removes address from data if isApplying is false', () => {
-            const data = ExecsDealing.pruneFormData(ctx.list[1]);
+            const data = ExecsDealing.pruneExecutorData(ctx.list[1]);
             assert.isUndefined(data.address);
         });
 
         it('removes postcode from data if isApplying is false', () => {
-            const data = ExecsDealing.pruneFormData(ctx.list[1]);
+            const data = ExecsDealing.pruneExecutorData(ctx.list[1]);
             assert.isUndefined(data.postcode);
         });
 
         it('removes currentName from data if isApplying is false', () => {
-            const data = ExecsDealing.pruneFormData(ctx.list[1]);
+            const data = ExecsDealing.pruneExecutorData(ctx.list[1]);
             assert.isUndefined(data.currentName);
         });
 
         it('removes hasOtherName from data if isApplying is false', () => {
-            const data = ExecsDealing.pruneFormData(ctx.list[1]);
+            const data = ExecsDealing.pruneExecutorData(ctx.list[1]);
             assert.isUndefined(data.hasOtherName);
         });
 
         it('removes postcodeAddress from data if isApplying is false', () => {
-            const data = ExecsDealing.pruneFormData(ctx.list[1]);
+            const data = ExecsDealing.pruneExecutorData(ctx.list[1]);
             assert.isUndefined(data.postcodeAddress);
         });
 
         it('removes currentNameReason from data if isApplying is false', () => {
-            const data = ExecsDealing.pruneFormData(ctx.list[1]);
+            const data = ExecsDealing.pruneExecutorData(ctx.list[1]);
             assert.isUndefined(data.currentNameReason);
         });
 

--- a/test/unit/testExecutorsInvite.js
+++ b/test/unit/testExecutorsInvite.js
@@ -47,7 +47,6 @@ describe('Executors-Invite', () => {
     });
 
     describe('action', () => {
-
         it('test inviteSuffix is removed from the context', () => {
             ctx = {
                 inviteSuffix: '-multiple'


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PRO-4264

### Change description ###
This PR cleans up redundant formdata when an executor is no longer dealing with the estate.

This PR also fixes a bug found on executors-additional-invite. Steps to reproduce the issue on master are below
```
add 2 executors
all alive
all dealing with estate
no alias
notify executors
sign out and in
change executors to 4
enter information
sign declaration
taken to additional-invite page
view urls for amending details - indexes should be off
```


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
