### PR TITLE
PRO-3956: Delete addresses array once all executors applying have agr…

### DIFF
--- a/app/steps/ui/copies/uk/index.js
+++ b/app/steps/ui/copies/uk/index.js
@@ -22,6 +22,13 @@ class CopiesUk extends ValidationStep {
     isComplete(ctx) {
         return [ctx.uk >= 0, 'inProgress'];
     }
+
+    action(ctx, formdata) {
+        super.action(ctx, formdata);
+        delete formdata.applicant.addresses;
+        delete formdata.deceased.addresses;
+        return [ctx, formdata];
+    }
 }
 
 module.exports = CopiesUk;

--- a/test/component/copies/testCopiesUk.js
+++ b/test/component/copies/testCopiesUk.js
@@ -49,12 +49,23 @@ describe('copies-uk', () => {
 
         it(`test it redirects to next page: ${expectedNextUrlForAssetsOverseas}`, (done) => {
             const data = {uk: '0'};
-            testWrapper.testRedirect(done, data, expectedNextUrlForAssetsOverseas);
+            const sessionData = require('test/data/copiesUk');
+            testWrapper.agent.post('/prepare-session/form')
+                .send(sessionData)
+                .end(() => {
+                    testWrapper.testRedirect(done, data, expectedNextUrlForAssetsOverseas);
+                });
         });
 
         it(`test it redirects to next page: ${expectedNextUrlForAssetsOverseas}`, (done) => {
             const data = {uk: '1'};
-            testWrapper.testRedirect(done, data, expectedNextUrlForAssetsOverseas);
+            const sessionData = require('test/data/copiesUk');
+
+            testWrapper.agent.post('/prepare-session/form')
+                .send(sessionData)
+                .end(() => {
+                    testWrapper.testRedirect(done, data, expectedNextUrlForAssetsOverseas);
+                });
         });
     });
 });

--- a/test/data/copiesUk.json
+++ b/test/data/copiesUk.json
@@ -1,0 +1,860 @@
+{
+  "iht": {
+    "form": "IHT205",
+    "method": "By post",
+    "netValue": 1,
+    "ihtFormId": "IHT205",
+    "netIHT205": "1",
+    "grossValue": 1,
+    "grossIHT205": "1"
+  },
+  "will": {
+    "codicils": "No"
+  },
+  "summary": {
+    "readyToDeclare": true
+  },
+  "deceased": {
+    "alias": "No",
+    "address": "67 Hill Rise Cuffley Potters Bar EN6 4RX",
+    "dob_day": 1,
+    "dod_day": 12,
+    "married": "No",
+    "dob_date": "1950-01-01T00:00:00.000Z",
+    "dob_year": 1950,
+    "dod_date": "2017-12-12T00:00:00.000Z",
+    "dod_year": 2017,
+    "lastName": "test",
+    "postcode": "EN6 4RX",
+    "addresses": [
+      {
+        "uprn": "100080969403",
+        "point": {
+          "type": "Point",
+          "coordinates": [
+            -0.1197166,
+            51.7146651
+          ]
+        },
+        "postcode": "EN6 4RX",
+        "post_town": "POTTERS BAR",
+        "building_name": "",
+        "po_box_number": "",
+        "postcode_type": "S",
+        "building_number": 47,
+        "department_name": "",
+        "formatted_address": "47 Hill Rise\nCuffley\nPotters Bar\nEN6 4RX",
+        "organisation_name": "",
+        "sub_building_name": "",
+        "thoroughfare_name": "HILL RISE",
+        "dependent_locality": "CUFFLEY",
+        "double_dependent_locality": "",
+        "dependent_thoroughfare_name": ""
+      },
+      {
+        "uprn": "100080969405",
+        "point": {
+          "type": "Point",
+          "coordinates": [
+            -0.1201702,
+            51.7152478
+          ]
+        },
+        "postcode": "EN6 4RX",
+        "post_town": "POTTERS BAR",
+        "building_name": "",
+        "po_box_number": "",
+        "postcode_type": "S",
+        "building_number": 57,
+        "department_name": "",
+        "formatted_address": "57 Hill Rise\nCuffley\nPotters Bar\nEN6 4RX",
+        "organisation_name": "",
+        "sub_building_name": "",
+        "thoroughfare_name": "HILL RISE",
+        "dependent_locality": "CUFFLEY",
+        "double_dependent_locality": "",
+        "dependent_thoroughfare_name": ""
+      },
+      {
+        "uprn": "100080969407",
+        "point": {
+          "type": "Point",
+          "coordinates": [
+            -0.1202956,
+            51.7153667
+          ]
+        },
+        "postcode": "EN6 4RX",
+        "post_town": "POTTERS BAR",
+        "building_name": "",
+        "po_box_number": "",
+        "postcode_type": "S",
+        "building_number": 59,
+        "department_name": "",
+        "formatted_address": "59 Hill Rise\nCuffley\nPotters Bar\nEN6 4RX",
+        "organisation_name": "",
+        "sub_building_name": "",
+        "thoroughfare_name": "HILL RISE",
+        "dependent_locality": "CUFFLEY",
+        "double_dependent_locality": "",
+        "dependent_thoroughfare_name": ""
+      },
+      {
+        "uprn": "100080969409",
+        "point": {
+          "type": "Point",
+          "coordinates": [
+            -0.1205062,
+            51.715523
+          ]
+        },
+        "postcode": "EN6 4RX",
+        "post_town": "POTTERS BAR",
+        "building_name": "",
+        "po_box_number": "",
+        "postcode_type": "S",
+        "building_number": 61,
+        "department_name": "",
+        "formatted_address": "61 Hill Rise\nCuffley\nPotters Bar\nEN6 4RX",
+        "organisation_name": "",
+        "sub_building_name": "",
+        "thoroughfare_name": "HILL RISE",
+        "dependent_locality": "CUFFLEY",
+        "double_dependent_locality": "",
+        "dependent_thoroughfare_name": ""
+      },
+      {
+        "uprn": "100080969411",
+        "point": {
+          "type": "Point",
+          "coordinates": [
+            -0.1205644,
+            51.7158656
+          ]
+        },
+        "postcode": "EN6 4RX",
+        "post_town": "POTTERS BAR",
+        "building_name": "",
+        "po_box_number": "",
+        "postcode_type": "S",
+        "building_number": 63,
+        "department_name": "",
+        "formatted_address": "63 Hill Rise\nCuffley\nPotters Bar\nEN6 4RX",
+        "organisation_name": "",
+        "sub_building_name": "",
+        "thoroughfare_name": "HILL RISE",
+        "dependent_locality": "CUFFLEY",
+        "double_dependent_locality": "",
+        "dependent_thoroughfare_name": ""
+      },
+      {
+        "uprn": "100080969413",
+        "point": {
+          "type": "Point",
+          "coordinates": [
+            -0.1204713,
+            51.716017
+          ]
+        },
+        "postcode": "EN6 4RX",
+        "post_town": "POTTERS BAR",
+        "building_name": "",
+        "po_box_number": "",
+        "postcode_type": "S",
+        "building_number": 65,
+        "department_name": "",
+        "formatted_address": "65 Hill Rise\nCuffley\nPotters Bar\nEN6 4RX",
+        "organisation_name": "",
+        "sub_building_name": "",
+        "thoroughfare_name": "HILL RISE",
+        "dependent_locality": "CUFFLEY",
+        "double_dependent_locality": "",
+        "dependent_thoroughfare_name": ""
+      },
+      {
+        "uprn": "100080969415",
+        "point": {
+          "type": "Point",
+          "coordinates": [
+            -0.1203633,
+            51.7161771
+          ]
+        },
+        "postcode": "EN6 4RX",
+        "post_town": "POTTERS BAR",
+        "building_name": "",
+        "po_box_number": "",
+        "postcode_type": "S",
+        "building_number": 67,
+        "department_name": "",
+        "formatted_address": "67 Hill Rise\nCuffley\nPotters Bar\nEN6 4RX",
+        "organisation_name": "",
+        "sub_building_name": "",
+        "thoroughfare_name": "HILL RISE",
+        "dependent_locality": "CUFFLEY",
+        "double_dependent_locality": "",
+        "dependent_thoroughfare_name": ""
+      },
+      {
+        "uprn": "100080969417",
+        "point": {
+          "type": "Point",
+          "coordinates": [
+            -0.1202713,
+            51.7163016
+          ]
+        },
+        "postcode": "EN6 4RX",
+        "post_town": "POTTERS BAR",
+        "building_name": "",
+        "po_box_number": "",
+        "postcode_type": "S",
+        "building_number": 69,
+        "department_name": "",
+        "formatted_address": "69 Hill Rise\nCuffley\nPotters Bar\nEN6 4RX",
+        "organisation_name": "",
+        "sub_building_name": "",
+        "thoroughfare_name": "HILL RISE",
+        "dependent_locality": "CUFFLEY",
+        "double_dependent_locality": "",
+        "dependent_thoroughfare_name": ""
+      }
+    ],
+    "dob_month": 1,
+    "dod_month": 12,
+    "firstName": "test",
+    "addressFound": "true",
+    "deceasedName": "test test",
+    "postcodeAddress": "67 Hill Rise Cuffley Potters Bar EN6 4RX",
+    "dob_formattedDate": "1 January 1950",
+    "dod_formattedDate": "12 December 2017"
+  },
+  "applicant": {
+    "address": "57 Hill Rise Cuffley Potters Bar EN6 4RX",
+    "lastName": "app_test",
+    "postcode": "EN6 4RX",
+    "addresses": [
+      {
+        "uprn": "100080969403",
+        "point": {
+          "type": "Point",
+          "coordinates": [
+            -0.1197166,
+            51.7146651
+          ]
+        },
+        "postcode": "EN6 4RX",
+        "post_town": "POTTERS BAR",
+        "building_name": "",
+        "po_box_number": "",
+        "postcode_type": "S",
+        "building_number": 47,
+        "department_name": "",
+        "formatted_address": "47 Hill Rise\nCuffley\nPotters Bar\nEN6 4RX",
+        "organisation_name": "",
+        "sub_building_name": "",
+        "thoroughfare_name": "HILL RISE",
+        "dependent_locality": "CUFFLEY",
+        "double_dependent_locality": "",
+        "dependent_thoroughfare_name": ""
+      },
+      {
+        "uprn": "100080969405",
+        "point": {
+          "type": "Point",
+          "coordinates": [
+            -0.1201702,
+            51.7152478
+          ]
+        },
+        "postcode": "EN6 4RX",
+        "post_town": "POTTERS BAR",
+        "building_name": "",
+        "po_box_number": "",
+        "postcode_type": "S",
+        "building_number": 57,
+        "department_name": "",
+        "formatted_address": "57 Hill Rise\nCuffley\nPotters Bar\nEN6 4RX",
+        "organisation_name": "",
+        "sub_building_name": "",
+        "thoroughfare_name": "HILL RISE",
+        "dependent_locality": "CUFFLEY",
+        "double_dependent_locality": "",
+        "dependent_thoroughfare_name": ""
+      },
+      {
+        "uprn": "100080969407",
+        "point": {
+          "type": "Point",
+          "coordinates": [
+            -0.1202956,
+            51.7153667
+          ]
+        },
+        "postcode": "EN6 4RX",
+        "post_town": "POTTERS BAR",
+        "building_name": "",
+        "po_box_number": "",
+        "postcode_type": "S",
+        "building_number": 59,
+        "department_name": "",
+        "formatted_address": "59 Hill Rise\nCuffley\nPotters Bar\nEN6 4RX",
+        "organisation_name": "",
+        "sub_building_name": "",
+        "thoroughfare_name": "HILL RISE",
+        "dependent_locality": "CUFFLEY",
+        "double_dependent_locality": "",
+        "dependent_thoroughfare_name": ""
+      },
+      {
+        "uprn": "100080969409",
+        "point": {
+          "type": "Point",
+          "coordinates": [
+            -0.1205062,
+            51.715523
+          ]
+        },
+        "postcode": "EN6 4RX",
+        "post_town": "POTTERS BAR",
+        "building_name": "",
+        "po_box_number": "",
+        "postcode_type": "S",
+        "building_number": 61,
+        "department_name": "",
+        "formatted_address": "61 Hill Rise\nCuffley\nPotters Bar\nEN6 4RX",
+        "organisation_name": "",
+        "sub_building_name": "",
+        "thoroughfare_name": "HILL RISE",
+        "dependent_locality": "CUFFLEY",
+        "double_dependent_locality": "",
+        "dependent_thoroughfare_name": ""
+      },
+      {
+        "uprn": "100080969411",
+        "point": {
+          "type": "Point",
+          "coordinates": [
+            -0.1205644,
+            51.7158656
+          ]
+        },
+        "postcode": "EN6 4RX",
+        "post_town": "POTTERS BAR",
+        "building_name": "",
+        "po_box_number": "",
+        "postcode_type": "S",
+        "building_number": 63,
+        "department_name": "",
+        "formatted_address": "63 Hill Rise\nCuffley\nPotters Bar\nEN6 4RX",
+        "organisation_name": "",
+        "sub_building_name": "",
+        "thoroughfare_name": "HILL RISE",
+        "dependent_locality": "CUFFLEY",
+        "double_dependent_locality": "",
+        "dependent_thoroughfare_name": ""
+      },
+      {
+        "uprn": "100080969413",
+        "point": {
+          "type": "Point",
+          "coordinates": [
+            -0.1204713,
+            51.716017
+          ]
+        },
+        "postcode": "EN6 4RX",
+        "post_town": "POTTERS BAR",
+        "building_name": "",
+        "po_box_number": "",
+        "postcode_type": "S",
+        "building_number": 65,
+        "department_name": "",
+        "formatted_address": "65 Hill Rise\nCuffley\nPotters Bar\nEN6 4RX",
+        "organisation_name": "",
+        "sub_building_name": "",
+        "thoroughfare_name": "HILL RISE",
+        "dependent_locality": "CUFFLEY",
+        "double_dependent_locality": "",
+        "dependent_thoroughfare_name": ""
+      },
+      {
+        "uprn": "100080969415",
+        "point": {
+          "type": "Point",
+          "coordinates": [
+            -0.1203633,
+            51.7161771
+          ]
+        },
+        "postcode": "EN6 4RX",
+        "post_town": "POTTERS BAR",
+        "building_name": "",
+        "po_box_number": "",
+        "postcode_type": "S",
+        "building_number": 67,
+        "department_name": "",
+        "formatted_address": "67 Hill Rise\nCuffley\nPotters Bar\nEN6 4RX",
+        "organisation_name": "",
+        "sub_building_name": "",
+        "thoroughfare_name": "HILL RISE",
+        "dependent_locality": "CUFFLEY",
+        "double_dependent_locality": "",
+        "dependent_thoroughfare_name": ""
+      },
+      {
+        "uprn": "100080969417",
+        "point": {
+          "type": "Point",
+          "coordinates": [
+            -0.1202713,
+            51.7163016
+          ]
+        },
+        "postcode": "EN6 4RX",
+        "post_town": "POTTERS BAR",
+        "building_name": "",
+        "po_box_number": "",
+        "postcode_type": "S",
+        "building_number": 69,
+        "department_name": "",
+        "formatted_address": "69 Hill Rise\nCuffley\nPotters Bar\nEN6 4RX",
+        "organisation_name": "",
+        "sub_building_name": "",
+        "thoroughfare_name": "HILL RISE",
+        "dependent_locality": "CUFFLEY",
+        "double_dependent_locality": "",
+        "dependent_thoroughfare_name": ""
+      }
+    ],
+    "firstName": "app_test",
+    "phoneNumber": "1234567890",
+    "addressFound": "true",
+    "nameAsOnTheWill": "Yes",
+    "postcodeAddress": "57 Hill Rise Cuffley Potters Bar EN6 4RX"
+  },
+  "executors": {
+    "list": [
+      {
+        "lastName": "app_test",
+        "firstName": "app_test",
+        "isApplying": true,
+        "isApplicant": true
+      },
+      {
+        "email": "douglas.rice@hmcts.net",
+        "mobile": "07773055642",
+        "address": "61 Hill Rise Cuffley Potters Bar EN6 4RX",
+        "fullName": "exec2",
+        "inviteId": "test-test-e285447c-0b13-42db-8e3e-f1554b66c847",
+        "postcode": "EN6 4RX",
+        "emailSent": true,
+        "isApplying": true,
+        "postcodeAddress": "61 Hill Rise Cuffley Potters Bar EN6 4RX"
+      },
+      {
+        "email": "douglas.rice@hmcts.net",
+        "mobile": "07773055642",
+        "address": "63 Hill Rise Cuffley Potters Bar EN6 4RX",
+        "fullName": "exec3",
+        "inviteId": "test-test-abe3aecd-a768-4231-8a67-bf3c68f7e9b0",
+        "postcode": "EN6 4RX",
+        "emailSent": true,
+        "isApplying": true,
+        "postcodeAddress": "63 Hill Rise Cuffley Potters Bar EN6 4RX"
+      }
+    ],
+    "alias": "No",
+    "allalive": "Yes",
+    "referrer": "ExecutorAddress",
+    "invitesSent": "true",
+    "addressFound": "true",
+    "executorsNumber": 3,
+    "executorsEmailChanged": false,
+    "executorsToNotifyList": [
+      {
+        "email": "douglas.rice@hmcts.net",
+        "mobile": "07773055642",
+        "address": "61 Hill Rise Cuffley Potters Bar EN6 4RX",
+        "fullName": "exec2",
+        "postcode": "EN6 4RX",
+        "isApplying": true,
+        "postcodeAddress": "61 Hill Rise Cuffley Potters Bar EN6 4RX"
+      },
+      {
+        "email": "douglas.rice@hmcts.net",
+        "mobile": "07773055642",
+        "fullName": "exec3",
+        "isApplying": true
+      }
+    ],
+    "otherExecutorsApplying": "Yes"
+  },
+  "declaration": {
+    "softStop": false,
+    "declaration": {
+      "accept": "I confirm that I will administer the estate of the person who died according to law, and that my application is truthful.",
+      "confirm": "We confirm that we will administer the estate of test test, according to law. We will:",
+      "requests": "If the probate registry (court) asks us to do so, we will:",
+      "understand": "We understand that:",
+      "confirmItem1": "collect the whole estate",
+      "confirmItem2": "keep full details (an inventory) of the estate",
+      "confirmItem3": "keep a full account of how the estate has been administered",
+      "requestsItem1": "provide the full details of the estate and how it has been administered",
+      "requestsItem2": "return the grant of probate to the court",
+      "submitWarning": "Once everyone has agreed the legal statement and made their declaration, this information can&rsquo;t be changed.",
+      "understandItem1": "our application will be rejected if we do not answer any questions about the information we have given",
+      "understandItem2": "criminal proceedings for fraud may be brought against us if we are found to have been deliberately untruthful or dishonest"
+    },
+    "legalStatement": {
+      "intro": "This statement is based on the information app_test app_test has given in their application. It will be stored as a public record.",
+      "deceased": "test test was born on 1 January 1950 and died on 12 December 2017, domiciled in England and Wales.",
+      "applicant": "We, app_test app_test of 57 Hill Rise Cuffley Potters Bar EN6 4RX, exec2 of 61 Hill Rise Cuffley Potters Bar EN6 4RX and exec3 of 63 Hill Rise Cuffley Potters Bar EN6 4RX, make the following statement:",
+      "executorsApplying": [
+        {
+          "name": "app_test app_test, an executor named in the will, is applying for probate.",
+          "sign": "app_test app_test will send to the probate registry what they believe to be the true and original last will and testament of test test."
+        },
+        {
+          "name": "exec2, an executor named in the will, is applying for probate.",
+          "sign": ""
+        },
+        {
+          "name": "exec3, an executor named in the will, is applying for probate.",
+          "sign": ""
+        }
+      ],
+      "deceasedEstateLand": "To the best of our knowledge, information and belief, there was no land vested in test test which was settled previously to the death (and not by the will) of test test and which remained settled land notwithstanding such death.",
+      "deceasedOtherNames": "",
+      "deceasedEstateValue": "The gross value for the estate amounts to £1 and the net value for the estate amounts to £1.",
+      "executorsNotApplying": []
+    },
+    "hasEmailChanged": false,
+    "declarationCheckbox": "true"
+  },
+  "applicantEmail": "woods12@test.com",
+  "documentupload": {},
+  "payloadVersion": "4.1.1",
+  "legalDeclaration": {
+    "headers": [
+      "In the High Court of Justice",
+      "Family Division",
+      "(Probate)"
+    ],
+    "deceased": "test test",
+    "sections": [
+      {
+        "title": "Legal statement",
+        "headingType": "large",
+        "declarationItems": [
+          {
+            "title": "We, app_test app_test of 57 Hill Rise Cuffley Potters Bar EN6 4RX, exec2 of 61 Hill Rise Cuffley Potters Bar EN6 4RX and exec3 of 63 Hill Rise Cuffley Potters Bar EN6 4RX, make the following statement:"
+          }
+        ]
+      },
+      {
+        "title": "The person who died",
+        "headingType": "small",
+        "declarationItems": [
+          {
+            "title": "test test was born on 1 January 1950 and died on 12 December 2017, domiciled in England and Wales. "
+          }
+        ]
+      },
+      {
+        "title": "The estate of the person who died",
+        "headingType": "small",
+        "declarationItems": [
+          {
+            "title": "The gross value for the estate amounts to £1 and the net value for the estate amounts to £1."
+          },
+          {
+            "title": "To the best of our knowledge, information and belief, there was no land vested in test test which was settled previously to the death (and not by the will) of test test and which remained settled land notwithstanding such death."
+          }
+        ]
+      },
+      {
+        "title": "Executors applying for probate",
+        "headingType": "small",
+        "declarationItems": [
+          {
+            "title": "app_test app_test, an executor named in the will, is applying for probate."
+          },
+          {
+            "title": "app_test app_test will send to the probate registry what they believe to be the true and original last will and testament of test test."
+          },
+          {
+            "title": "exec2, an executor named in the will, is applying for probate."
+          },
+          {
+            "title": "exec3, an executor named in the will, is applying for probate."
+          }
+        ]
+      },
+      {
+        "title": "Declaration",
+        "headingType": "large",
+        "declarationItems": [
+          {
+            "title": "We confirm that we will administer the estate of test test, according to law. We will:",
+            "values": [
+              "collect the whole estate",
+              "keep full details (an inventory) of the estate",
+              "keep a full account of how the estate has been administered"
+            ]
+          },
+          {
+            "title": "If the probate registry (court) asks us to do so, we will:",
+            "values": [
+              "provide the full details of the estate and how it has been administered",
+              "return the grant of probate to the court"
+            ]
+          },
+          {
+            "title": "We understand that:",
+            "values": [
+              "our application will be rejected if we do not answer any questions about the information we have given",
+              "criminal proceedings for fraud may be brought against us if we are found to have been deliberately untruthful or dishonest"
+            ]
+          }
+        ]
+      }
+    ],
+    "dateCreated": "3/1/2019, 12:45:14 PM"
+  },
+  "checkAnswersSummary": {
+    "sections": [
+      {
+        "type": "heading-medium",
+        "title": "About the person who died",
+        "questionAndAnswers": [
+          {
+            "answers": [
+              "test"
+            ],
+            "question": "First name(s)"
+          },
+          {
+            "answers": [
+              "test"
+            ],
+            "question": "Last name(s)"
+          },
+          {
+            "answers": [
+              "No"
+            ],
+            "question": "Did test test have assets in another name?"
+          },
+          {
+            "answers": [
+              "No"
+            ],
+            "question": "Did test test get married or enter into a civil partnership after the will was signed?"
+          },
+          {
+            "answers": [
+              "1 January 1950"
+            ],
+            "question": "What was their date of birth?"
+          },
+          {
+            "answers": [
+              "12 December 2017"
+            ],
+            "question": "What was the date that they died?"
+          },
+          {
+            "answers": [
+              "67 Hill Rise Cuffley Potters Bar EN6 4RX"
+            ],
+            "question": "What was the permanent address at the time of their death?"
+          },
+          {
+            "answers": [
+              "No"
+            ],
+            "question": "Were any updates (‘codicils’) made to the will?"
+          }
+        ]
+      },
+      {
+        "type": "heading-medium",
+        "title": "Uploaded documents",
+        "questionAndAnswers": [
+          {
+            "answers": [
+              "No documents have been uploaded"
+            ],
+            "question": "Death Certificate"
+          }
+        ]
+      },
+      {
+        "type": "heading-medium",
+        "title": "Inheritance tax",
+        "questionAndAnswers": [
+          {
+            "answers": [
+              "By post"
+            ],
+            "question": "How was the Inheritance Tax (IHT) form submitted?"
+          },
+          {
+            "answers": [
+              "IHT 205 - there was no inheritance tax to pay"
+            ],
+            "question": "Which paper form was filled in?"
+          },
+          {
+            "answers": [
+              "1"
+            ],
+            "question": "Gross value of the estate in £"
+          },
+          {
+            "answers": [
+              "1"
+            ],
+            "question": "Net value of the estate in £"
+          }
+        ]
+      },
+      {
+        "type": "heading-medium",
+        "title": "The executors",
+        "questionAndAnswers": [
+          {
+            "answers": [
+              "3"
+            ],
+            "question": "How many past and present executors are named on the will and any updates (‘codicils’)?"
+          },
+          {
+            "answers": [
+              "Yes"
+            ],
+            "question": "Are all the executors alive?"
+          }
+        ]
+      },
+      {
+        "type": "heading-small",
+        "title": "About you",
+        "questionAndAnswers": [
+          {
+            "answers": [
+              "app_test"
+            ],
+            "question": "First name(s)"
+          },
+          {
+            "answers": [
+              "app_test"
+            ],
+            "question": "Last name(s)"
+          },
+          {
+            "answers": [
+              "Yes"
+            ],
+            "question": "Is your name ‘app_test app_test’ exactly what appears on the will?"
+          },
+          {
+            "answers": [
+              "1234567890"
+            ],
+            "question": "Phone number"
+          },
+          {
+            "answers": [
+              "57 Hill Rise Cuffley Potters Bar EN6 4RX"
+            ],
+            "question": "What is your address?"
+          }
+        ]
+      },
+      {
+        "type": "heading-small",
+        "title": "Other executors applying for probate",
+        "questionAndAnswers": [
+          {
+            "answers": [
+              "Yes"
+            ],
+            "question": "Will any of the other executors be dealing with the estate?"
+          },
+          {
+            "answers": [
+              "\n                                    exec2\n                                ",
+              "\n                                    exec3\n                                "
+            ],
+            "question": "Which executors will be dealing with the estate?"
+          }
+        ]
+      },
+      {
+        "type": "heading-small",
+        "title": "Second executor applying for probate",
+        "questionAndAnswers": [
+          {
+            "answers": [
+              "exec2"
+            ],
+            "question": "Name on will"
+          },
+          {
+            "answers": [
+              "61 Hill Rise Cuffley Potters Bar EN6 4RX"
+            ],
+            "question": "Address"
+          },
+          {
+            "answers": [
+              "07773055642"
+            ],
+            "question": "Mobile number"
+          },
+          {
+            "answers": [
+              "douglas.rice@hmcts.net"
+            ],
+            "question": "Email address"
+          }
+        ]
+      },
+      {
+        "type": "heading-small",
+        "title": "Third executor applying for probate",
+        "questionAndAnswers": [
+          {
+            "answers": [
+              "exec3"
+            ],
+            "question": "Name on will"
+          },
+          {
+            "answers": [
+              "63 Hill Rise Cuffley Potters Bar EN6 4RX"
+            ],
+            "question": "Address"
+          },
+          {
+            "answers": [
+              "07773055642"
+            ],
+            "question": "Mobile number"
+          },
+          {
+            "answers": [
+              "douglas.rice@hmcts.net"
+            ],
+            "question": "Email address"
+          }
+        ]
+      }
+    ],
+    "pageTitle": "\n            Check your answers\n        ",
+    "mainParagraph": "Check the information below carefully. This will form a record of your application for probate. It will also be stored as a public record, and will be able to be viewed online."
+  }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PRO-3956


### Change description ###
Remove the addresses array once all applying executors have agreed to Statement of Truth - so that it is not saved to the database


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
