### PR TITLE
PRO-4894: Dynamic deceased name on Assets Overseas page

### DIFF
--- a/app/resources/en/translation/assets/overseas.json
+++ b/app/resources/en/translation/assets/overseas.json
@@ -1,10 +1,10 @@
 {
   "title": "Did the person who died have assets outside the UK",
-  "question": "Did the person who died have assets outside the UK?",
+  "question": "Did {deceasedName} have assets outside the UK?",
   "hint": "This could be shares or property that they held outside the UK. If they did, you need special copies of the grant of probate to use outside of the UK.",
   "optionYes": "Yes",
   "optionNo": "No",
-  "legend": "Did the person who died have assets outside the UK?",
+  "legend": "Did {deceasedName} have assets outside the UK?",
 
   "errors": {
     "assetsoverseas": {

--- a/app/steps/ui/assets/overseas/index.js
+++ b/app/steps/ui/assets/overseas/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const ValidationStep = require('app/core/steps/ValidationStep');
+const FormatName = require('app/utils/FormatName');
 const json = require('app/resources/en/translation/assets/overseas');
 
 class AssetsOverseas extends ValidationStep {
@@ -9,13 +10,19 @@ class AssetsOverseas extends ValidationStep {
         return '/assets-overseas';
     }
 
+    getContextData(req) {
+        const ctx = super.getContextData(req);
+        const formdata = req.session.form;
+        ctx.deceasedName = FormatName.format(formdata.deceased);
+        return ctx;
+    }
+
     nextStepOptions() {
-        const nextStepOptions = {
+        return {
             options: [
                 {key: 'assetsoverseas', value: json.optionYes, choice: 'assetsoverseas'}
             ]
         };
-        return nextStepOptions;
     }
 }
 

--- a/app/steps/ui/assets/overseas/index.js
+++ b/app/steps/ui/assets/overseas/index.js
@@ -24,6 +24,12 @@ class AssetsOverseas extends ValidationStep {
             ]
         };
     }
+
+    action(ctx, formdata) {
+        super.action(ctx, formdata);
+        delete ctx.deceasedName;
+        return [ctx, formdata];
+    }
 }
 
 module.exports = AssetsOverseas;

--- a/app/steps/ui/assets/overseas/template.html
+++ b/app/steps/ui/assets/overseas/template.html
@@ -4,7 +4,7 @@
 {% from "widgets/radiobuttons.html" import optionsRadio %}
 
 {% block question %}
-    <h1 class="form-title heading-large">{{ content.question }}</h1>
+    <h1 class="form-title heading-large">{{ content.question | replace('{deceasedName}', fields.deceasedName.value) | safe }}</h1>
 {% endblock %}
 
 {% block form_content %}

--- a/test/component/assets/testAssetsOverseas.js
+++ b/test/component/assets/testAssetsOverseas.js
@@ -22,7 +22,20 @@ describe('assets-overseas', () => {
         testHelpBlockContent.runTest('AssetsOverseas');
 
         it('test content loaded on the page', (done) => {
-            testWrapper.testContent(done);
+            const sessionData = {
+                deceased: {
+                    firstName: 'John',
+                    lastName: 'Doe'
+                }
+            };
+
+            testWrapper.agent.post('/prepare-session/form')
+                .send(sessionData)
+                .end(() => {
+                    const contentData = {deceasedName: 'John Doe'};
+
+                    testWrapper.testContent(done, [], contentData);
+                });
         });
 
         it(`test it redirects to Copies Overseas page: ${expectedNextUrlForCopiesOverseas}`, (done) => {

--- a/test/unit/testAssetsOverseas.js
+++ b/test/unit/testAssetsOverseas.js
@@ -1,0 +1,53 @@
+'use strict';
+
+const initSteps = require('app/core/initSteps');
+const expect = require('chai').expect;
+const steps = initSteps([`${__dirname}/../../app/steps/action/`, `${__dirname}/../../app/steps/ui`]);
+const AssetsOverseas = steps.AssetsOverseas;
+const content = require('app/resources/en/translation/assets/overseas');
+
+describe('AssetsOutside', () => {
+    describe('getUrl()', () => {
+        it('should return the correct url', (done) => {
+            const url = AssetsOverseas.constructor.getUrl();
+            expect(url).to.equal('/assets-overseas');
+            done();
+        });
+    });
+
+    describe('getContextData()', () => {
+        let ctx;
+        let req;
+
+        it('should return the context with the deceased name', (done) => {
+            req = {
+                session: {
+                    form: {
+                        deceased: {
+                            firstName: 'John',
+                            lastName: 'Doe'
+                        }
+                    }
+                }
+            };
+
+            ctx = AssetsOverseas.getContextData(req);
+            expect(ctx.deceasedName).to.equal('John Doe');
+            done();
+        });
+    });
+
+    describe('nextStepOptions()', () => {
+        it('should return the correct options', (done) => {
+            const nextStepOptions = AssetsOverseas.nextStepOptions();
+            expect(nextStepOptions).to.deep.equal({
+                options: [{
+                    key: 'assetsoverseas',
+                    value: content.optionYes,
+                    choice: 'assetsoverseas'
+                }]
+            });
+            done();
+        });
+    });
+});

--- a/test/unit/testAssetsOverseas.js
+++ b/test/unit/testAssetsOverseas.js
@@ -50,4 +50,15 @@ describe('AssetsOutside', () => {
             done();
         });
     });
+
+    describe('action()', () => {
+        it('test that context variables are removed and empty object returned', () => {
+            let formdata = {};
+            let ctx = {
+                deceasedName: 'Dee Ceased'
+            };
+            [ctx, formdata] = AssetsOverseas.action(ctx, formdata);
+            expect(ctx).to.deep.equal({});
+        });
+    });
 });


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PRO-4894

### Change description ###
Dynamic deceased name on Assets Overseas page

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[X] No
```