### PR TITLE
PRO-5154: Change Zap to Medium alerts as Information alerts are causi…

### DIFF
--- a/security.sh
+++ b/security.sh
@@ -16,4 +16,4 @@ while !(curl -s http://0.0.0.0:1001) > /dev/null
   echo 'Changing owner from $(id -u):$(id -g) to $(id -u):$(id -u)'
   chown -R $(id -u):$(id -u) activescan.html
   cp *.html functional-output/
-  zap-cli -p 1001 alerts -l Informational
+  zap-cli -p 1001 alerts -l Medium


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PRO-5162


### Change description ###
Informational alerts from ZAP scan cause pipeline to fail - change alerting to Medium


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
