### PR TITLE
PRO-5313: Stop will left in formdata

### DIFF
--- a/app/steps/ui/screeners/willleft/index.js
+++ b/app/steps/ui/screeners/willleft/index.js
@@ -21,6 +21,7 @@ class WillLeft extends EligibilityValidationStep {
 
     handlePost(ctx, errors, formdata, session) {
         session.willLeft = ctx.left;
+        session.willLeft = ctx.left;
         return super.handlePost(ctx, errors, formdata, session);
     }
 

--- a/app/steps/ui/screeners/willleft/index.js
+++ b/app/steps/ui/screeners/willleft/index.js
@@ -21,7 +21,6 @@ class WillLeft extends EligibilityValidationStep {
 
     handlePost(ctx, errors, formdata, session) {
         session.willLeft = ctx.left;
-        session.willLeft = ctx.left;
         return super.handlePost(ctx, errors, formdata, session);
     }
 

--- a/app/steps/ui/screeners/willleft/index.js
+++ b/app/steps/ui/screeners/willleft/index.js
@@ -19,11 +19,6 @@ class WillLeft extends EligibilityValidationStep {
         return super.getContextData(req, res, pageUrl, fieldKey, featureToggles);
     }
 
-    handlePost(ctx, errors, formdata, session) {
-        session.willLeft = ctx.left;
-        return super.handlePost(ctx, errors, formdata, session);
-    }
-
     nextStepUrl(req, ctx) {
         return this.next(req, ctx).constructor.getUrl('noWill');
     }

--- a/test/unit/screeners/testWillLeft.js
+++ b/test/unit/screeners/testWillLeft.js
@@ -41,28 +41,6 @@ describe('WillLeft', () => {
         });
     });
 
-    describe('handlePost()', () => {
-        it('should remove session.form and set session.willLeft', (done) => {
-            const ctxToTest = {
-                left: content.optionYes
-            };
-            const errorsToTest = {};
-            const formdata = {};
-            const session = {
-                form: {}
-            };
-            const [ctx, errors] = WillLeft.handlePost(ctxToTest, errorsToTest, formdata, session);
-            expect(session).to.deep.equal({
-                willLeft: content.optionYes
-            });
-            expect(ctx).to.deep.equal({
-                left: content.optionYes
-            });
-            expect(errors).to.deep.equal({});
-            done();
-        });
-    });
-
     describe('nextStepUrl()', () => {
         it('should return the correct url when Yes is given', (done) => {
             const req = {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PRO-5313


### Change description ###
Current one of the screen questions is being saved to formdata which in turn is getting sent
to CCD and as CCD does not expect this data it is rejecting the payload and not creating an initial Probate application.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
