### PR TITLE
PRO-5376: Fix to not clear case state if undefined.

### DIFF
--- a/app/steps/ui/payment/status/index.js
+++ b/app/steps/ui/payment/status/index.js
@@ -90,8 +90,10 @@ class PaymentStatus extends Step {
 
             const [updateCcdCaseResponse, errors] = yield this.updateCcdCasePaymentStatus(ctx, formdata);
             this.setErrors(options, errors);
-            set(formdata, 'ccdCase.state', updateCcdCaseResponse.caseState);
 
+            if (typeof updateCcdCaseResponse.caseState !== 'undefined') {
+                set(formdata, 'ccdCase.state', updateCcdCaseResponse.caseState);
+            }
             if (getPaymentResponse.status !== 'Success') {
                 options.redirect = true;
                 options.url = `${this.steps.PaymentBreakdown.constructor.getUrl()}?status=failure`;

--- a/test/unit/testPaymentStatus.js
+++ b/test/unit/testPaymentStatus.js
@@ -148,9 +148,10 @@ describe('PaymentStatus', () => {
         });
 
         it('should set redirect to true and payment status to failure if payment is not successful', (done) => {
-            nockMock.reply(200, {caseState: 'CaseCreated'});
+            nockMock.reply(200, {caseState: 'CasePaymentFailed'});
 
             expectedFormData.payment.status = 'Failed';
+            expectedFormData.ccdCase.state = 'CasePaymentFailed';
 
             const revert = PaymentStatus.__set__({
                 Payment: class {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PRO-5376

### Change description ###
After cancelling a payment, if the user logs out and logs in again and completes a successful payment the payment validation on /payment-status still uses the old failed reference which doesn't return caseState value and results in the formdata entry being wiped.

This simple change just checks the caseState value is populated first before writing to the formdata. Included an extra check in the unit tests.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
