### PR TITLE
PRO-6270: Replace current url on survey links appearing on error pages

### DIFF
--- a/app/views/errors/403.html
+++ b/app/views/errors/403.html
@@ -14,3 +14,12 @@
         </div>
     </div>
 {% endblock %}
+
+{% block beforeContent %}
+    {{ govukPhaseBanner({
+        tag: {
+            text: common.phase
+        },
+        html: common.feedback | replace("{smartSurveyFeedbackUrl}", globals.links.survey) | replace("{currentPageUrl}", '403') | safe
+    }) }}
+{% endblock %}

--- a/app/views/errors/404.html
+++ b/app/views/errors/404.html
@@ -14,3 +14,12 @@
         </div>
     </div>
 {% endblock %}
+
+{% block beforeContent %}
+    {{ govukPhaseBanner({
+        tag: {
+            text: common.phase
+        },
+        html: common.feedback | replace("{smartSurveyFeedbackUrl}", globals.links.survey) | replace("{currentPageUrl}", '404') | safe
+    }) }}
+{% endblock %}

--- a/app/views/errors/500.html
+++ b/app/views/errors/500.html
@@ -14,3 +14,12 @@
         </div>
     </div>
 {% endblock %}
+
+{% block beforeContent %}
+    {{ govukPhaseBanner({
+        tag: {
+            text: common.phase
+        },
+        html: common.feedback | replace("{smartSurveyFeedbackUrl}", globals.links.survey) | replace("{currentPageUrl}", '500') | safe
+    }) }}
+{% endblock %}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PRO-6270

### Change description ###
Replace current url on survey links appearing on error pages

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[X] No
```