### PR TITLE
PRO-6869: Add 2 unit tests for Payment Status

### DIFF
--- a/test/unit/payment/testPaymentStatus.js
+++ b/test/unit/payment/testPaymentStatus.js
@@ -112,6 +112,15 @@ describe('PaymentStatus', () => {
         nock.cleanAll();
     });
 
+    describe('getUrl()', () => {
+        it('should return the correct url', (done) => {
+            const paymentStatus = new PaymentStatus(steps, section, templatePath, i18next, schema);
+            const url = paymentStatus.constructor.getUrl();
+            expect(url).to.equal('/payment-status');
+            done();
+        });
+    });
+
     describe('runnerOptions', () => {
         it('redirect if there is an authorise failure', (done) => {
             revertSubmitData(expectedFormData);
@@ -347,6 +356,26 @@ describe('PaymentStatus', () => {
             }).catch(err => {
                 done(err);
             });
+        });
+    });
+
+    describe('action()', () => {
+        it('test that context variables are removed and empty object returned', () => {
+            const paymentStatus = new PaymentStatus(steps, section, templatePath, i18next, schema);
+            let formdata = {};
+            let ctx = {
+                authToken: '',
+                userId: '',
+                regId: '',
+                sessionId: '',
+                errors: '',
+                paymentNotRequired: '',
+                paymentDue: '',
+                payment: '',
+                paymentBreakdownSkipped: ''
+            };
+            [ctx, formdata] = paymentStatus.action(ctx, formdata);
+            expect(ctx).to.deep.equal({});
         });
     });
 });


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PRO-6869

### Change description ###
Add 2 unit tests for Payment Status to increase code coverage in Sonar Scan

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[X] No
```