### PR TITLE
PRO-7305: Call ready check once

### DIFF
--- a/app/utils/FeatureToggle.js
+++ b/app/utils/FeatureToggle.js
@@ -29,7 +29,7 @@ class FeatureToggle {
         }
 
         try {
-            params.launchDarkly.client.once('ready', () => {
+            this.onceReady(params.launchDarkly, () => {
                 params.launchDarkly.client.variation(featureToggleKey, ldUser, ldDefaultValue, (err, showFeature) => {
                     if (!err) {
                         logger(sessionId).info(`Checking feature toggle: ${params.featureToggleKey}, isEnabled: ${showFeature}`);
@@ -48,6 +48,17 @@ class FeatureToggle {
             });
         } catch (err) {
             params.next(err);
+        }
+    }
+
+    onceReady(ld, callback) {
+        if (!ld.ready) {
+            ld.client.once('ready', () => {
+                ld.ready = true;
+                callback();
+            });
+        } else {
+            callback();
         }
     }
 

--- a/test/unit/utils/testFeatureToggle.js
+++ b/test/unit/utils/testFeatureToggle.js
@@ -14,7 +14,8 @@ describe('FeatureToggle', () => {
                 paths: ['test/data/launchdarkly/simple_flag_data.yaml']
             });
             const ldConfig = {
-                updateProcessor: dataSource
+                updateProcessor: dataSource,
+                sendEvents: false
             };
 
             const ldClient = LaunchDarkly.init(config.featureToggles.launchDarklyKey, ldConfig);
@@ -37,9 +38,10 @@ describe('FeatureToggle', () => {
             const featureToggle = new FeatureToggle();
 
             featureToggle.checkToggle(params);
+            featureToggle.checkToggle(params); // Checking a second call the ld doesn't hang
 
             setTimeout(() => {
-                expect(params.callback.calledOnce).to.equal(true);
+                expect(params.callback.calledTwice).to.equal(true);
                 expect(params.callback.calledWith({
                     req: params.req,
                     res: params.res,


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PRO-7305

### Change description ###
Only check for LaunchDarkly ready event once

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[X] No
```