### PR TITLE
DTSPB-999: Get crossbrowser tests running on Chrome

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -4,7 +4,7 @@ properties([
         pipelineTriggers([cron('00 02 * * *')]),
         parameters([
                 string(name: 'ENVIRONMENT', defaultValue: 'aat', description: 'Environment to test'),
-                string(name: 'test_path', defaultValue: './paths/**/*.test.js', description: 'any three like ./paths/probate/*.js or ./paths/generic/*.js or ./paths/intestacy/*.js'),
+                string(name: 'test_path', defaultValue: './paths/**/*.js', description: 'any three like ./paths/probate/*.js or ./paths/generic/*.js or ./paths/intestacy/*.js'),
                 string(name: 'URL_TO_TEST', defaultValue: 'https://probate.aat.platform.hmcts.net', description: 'The URL you want to run these tests against'),
         ])
 ])

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -4,7 +4,7 @@ properties([
         pipelineTriggers([cron('00 02 * * *')]),
         parameters([
                 string(name: 'ENVIRONMENT', defaultValue: 'aat', description: 'Environment to test'),
-                string(name: 'test_path', defaultValue: './paths/**/*.js', description: 'any three like ./paths/probate/*.js or ./paths/generic/*.js or ./paths/intestacy/*.js'),
+                string(name: 'test_path', defaultValue: './paths/**/*.test.js', description: 'any three like ./paths/probate/*.js or ./paths/generic/*.js or ./paths/intestacy/*.js'),
                 string(name: 'URL_TO_TEST', defaultValue: 'https://probate.aat.platform.hmcts.net', description: 'The URL you want to run these tests against'),
         ])
 ])
@@ -51,7 +51,7 @@ static LinkedHashMap<String, Object> secret(String secretName, String envVar) {
 withNightlyPipeline("nodejs", product, component) {
     loadVaultSecrets(secrets)
     env.TEST_URL = params.URL_TO_TEST
-    env.FE_E2E_TEST_PATH_TO_RUN =  params.test_path
+    env.FE_E2E_TEST_PATH_TO_RUN = params.test_path
     //enableFullFunctionalTest()
     enableCrossBrowserTest()
 //    enableSecurityScan()  //we do this in otrher builds

--- a/config/testing-http-dk.yaml
+++ b/config/testing-http-dk.yaml
@@ -13,9 +13,9 @@ TestIdamUserGroup: 'caseworker'
 TestOutputDir: './output'
 TestPathToRun: './paths/**/*.test.js'
 TestProxy: 'socks5:proxyout.reform.hmcts.net:8080'
-TestRetryFeatures: 4
-TestRetryScenarios: 4
-TestRetrySteps: 4
+TestRetryFeatures: 2
+TestRetryScenarios: 2
+TestRetrySteps: 2
 TestShowBrowser: false
 TestUseGovPay: 'true'
 TestUseIdam: 'true'
@@ -54,7 +54,7 @@ govPayTestCardDetails:
   addressCity: 'London'
   addressPostcode: 'SW1A1AA'
 
-validation: 
+validation:
   url: 'http://localhost:8081/validate'
 
 TestGovUkConfirmPaymentUrl: 'www.payments.service.gov.uk'

--- a/test/end-to-end/codecept.conf.js
+++ b/test/end-to-end/codecept.conf.js
@@ -30,6 +30,9 @@ exports.config = {
         JSWait: {
             require: './helpers/JSWait.js'
         },
+        IDAMHelper: {
+            require: './helpers/IDAMHelper.js'
+        }
     },
     include: {
         I: './pages/steps.js'

--- a/test/end-to-end/helpers/IDAMHelper.js
+++ b/test/end-to-end/helpers/IDAMHelper.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const Helper = codecept_helper;
+const request = require('request');
+const util = require('util');
+const config = require('config');
+
+class IDAMHelper extends Helper {
+    // Creating a test user via a custom Helper means that CodeceptJS's .retry()
+    // can be used to retry the step if it fails.
+    async createAUser(options) {
+        if (config.TestUseIdam === 'true') {
+            console.log(`Creating user: ${options.getTestCitizenEmail()}`);
+            const httpReq = util.promisify(request);
+            options.userDetails =
+                {
+                    'email': options.getTestCitizenEmail(),
+                    'forename': options.getTestCitizenName(),
+                    'surname': options.getTestCitizenName(),
+                    'password': options.getTestCitizenPassword(),
+                    'roles': [{'code': options.getTestRole()}],
+                    'userGroup': {'code': options.getTestIdamUserGroup()}
+                };
+
+            try {
+                const response = await httpReq({
+                    url: options.getTestAddUserURL(),
+                    proxy: options.getUseProxy() === 'true' ? options.getProxy() : null,
+                    method: 'POST',
+                    json: true, // <--Very important!!!
+                    body: options.userDetails
+                });
+                if (!response) {
+                    throw new Error('TestConfigurator.getBefore: Using proxy - ERROR. No error raised, but no response obtained.');
+                } else if (response.statusCode !== 201) {
+                    throw new Error('TestConfigurator.getBefore: Using proxy - Unable to create user.  Response from IDAM was: ' + response.statusCode);
+                } else {
+                    console.log('User created (via proxy)', options.userDetails);
+                }
+            } catch (err) {
+                throw new Error(`TestConfigurator.getBefore: Using proxy - ERROR: ${err.message}\nError stack:\n${err.stack}`);
+            }
+        }
+    }
+}
+
+module.exports = IDAMHelper;

--- a/test/end-to-end/helpers/JSWait.js
+++ b/test/end-to-end/helpers/JSWait.js
@@ -64,14 +64,9 @@ class JSWait extends codecept_helper {
                 document.querySelector('#newPostCode').value = 'postcode';
             });
         } else {
-            const browserName = this.helpers.WebDriver.config.browser;
-
-            // browserName !== 'internet explorer' &&  removed
-            if (browserName !== 'MicrosoftEdge') {
-                await helper.waitForVisible('#postcode');
-                await helper.click('.govuk-details__summary-text');
-                await helper.waitForVisible('#addressLine1');
-            }
+            await helper.waitForVisible('#postcode');
+            await helper.click('.govuk-details__summary-text');
+            await helper.waitForVisible('#addressLine1');
 
             await helper.fillField('#addressLine1', 'test address for deceased line 1');
             await helper.fillField('#addressLine2', 'test address for deceased line 2');

--- a/test/end-to-end/helpers/LaunchDarkly.js
+++ b/test/end-to-end/helpers/LaunchDarkly.js
@@ -4,7 +4,7 @@ const testConfig = require('config');
 const launchDarkly = require('launchdarkly-node-server-sdk');
 
 class LaunchDarkly {
-    constructor() {
+    initialise() {
         this.ready = false;
         const options = testConfig.featureToggles.enabled ? {diagnosticOptOut: true} : {offline: true};
         this.client = launchDarkly.init(testConfig.featureToggles.launchDarklyKey, options);

--- a/test/end-to-end/helpers/LaunchDarkly.js
+++ b/test/end-to-end/helpers/LaunchDarkly.js
@@ -4,7 +4,7 @@ const testConfig = require('config');
 const launchDarkly = require('launchdarkly-node-server-sdk');
 
 class LaunchDarkly {
-    initialise() {
+    constructor() {
         this.ready = false;
         const options = testConfig.featureToggles.enabled ? {diagnosticOptOut: true} : {offline: true};
         this.client = launchDarkly.init(testConfig.featureToggles.launchDarklyKey, options);

--- a/test/end-to-end/helpers/TestConfigurator.js
+++ b/test/end-to-end/helpers/TestConfigurator.js
@@ -32,7 +32,6 @@ class TestConfigurator {
 
     async initLaunchDarkly() {
         this.launchDarkly = await new LaunchDarkly();
-        await this.launchDarkly.initialise();
     }
 
     async getBefore() {

--- a/test/end-to-end/helpers/TestConfigurator.js
+++ b/test/end-to-end/helpers/TestConfigurator.js
@@ -27,7 +27,7 @@ class TestConfigurator {
         this.retryScenarios = testConfig.TestRetryScenarios;
         this.testUseProxy = testConfig.TestUseProxy;
         this.testProxy = testConfig.TestProxy;
-        this.launchDarkly = {};
+        this.launchDarkly = null;
     }
 
     async initLaunchDarkly() {
@@ -40,56 +40,14 @@ class TestConfigurator {
             this.setTestCitizenName();
             this.setTestCitizenPassword();
         }
-
-        this.setEnvVars();
-
-        const httpReq = util.promisify(request);
-
-        if (this.useIdam === 'true') {
-            this.userDetails =
-                {
-                    'email': this.getTestCitizenEmail(),
-                    'forename': this.getTestCitizenName(),
-                    'surname': this.getTestCitizenName(),
-                    'password': this.getTestCitizenPassword(),
-                    'roles': [{'code': this.getTestRole()}],
-                    'userGroup': {'code': this.getTestIdamUserGroup()}
-                };
-
-            try {
-
-                let response = null;
-                if (this.getUseProxy() === 'true') {
-                    response = await httpReq({
-                        url: this.getTestAddUserURL(),
-                        proxy: this.getProxy(),
-                        method: 'POST',
-                        json: true, // <--Very important!!!
-                        body: this.userDetails
-                    });
-                } else {
-                    response = await httpReq({
-                        url: this.getTestAddUserURL(),
-                        method: 'POST',
-                        json: true, // <--Very important!!!
-                        body: this.userDetails
-                    });
-                }
-                if (!response) {
-                    throw new Error('TestConfigurator.getBefore: Using proxy - ERROR. No error raised, but no response obtained.');
-                } else if (response.statusCode !== 201) {
-                    throw new Error('TestConfigurator.getBefore: Using proxy - Unable to create user.  Response from IDAM was: ' + response.statusCode);
-                } else {
-                    console.log('User created (via proxy)', this.userDetails);
-                }
-            } catch (err) {
-                throw new Error(`TestConfigurator.getBefore: Using proxy - ERROR: ${err.message}\nError stack:\n${err.stack}`);
-            }
-        }
+        await this.setEnvVars();
     }
 
     getAfter() {
-        this.launchDarkly.close();
+        this.deleteIdamUser();
+        if (this.launchDarkly) {
+            this.launchDarkly.close();
+        }
     }
 
     setTestCitizenName() {
@@ -136,6 +94,26 @@ class TestConfigurator {
 
     idamInUseText(scenarioText) {
         return (this.useIdam === 'true') ? scenarioText + ' - With Idam' : scenarioText + ' - Without Idam';
+    }
+
+    async deleteIdamUser() {
+        if (this.useIdam === 'true') {
+            const email = this.getTestCitizenEmail();
+            console.log(`Deleting user: ${email}`);
+            try {
+                const httpReq = util.promisify(request);
+                const response = await httpReq({
+                    url: this.getTestDeleteUserURL() + email,
+                    proxy: this.getUseProxy() === 'true' ? this.getProxy() : null,
+                    method: 'DELETE'
+                });
+                if (response.statusCode > 204) {
+                    console.log(`Delete IDAM test user '${email}' result: ${response.statusCode}, ${response.statusMessage}`);
+                }
+            } catch (err) {
+                console.error(`IDAM test user deletion unsuccessful: ${err.message}`);
+            }
+        }
     }
 
     setEnvVars() {

--- a/test/end-to-end/helpers/TestConfigurator.js
+++ b/test/end-to-end/helpers/TestConfigurator.js
@@ -27,7 +27,12 @@ class TestConfigurator {
         this.retryScenarios = testConfig.TestRetryScenarios;
         this.testUseProxy = testConfig.TestUseProxy;
         this.testProxy = testConfig.TestProxy;
-        this.launchDarkly = new LaunchDarkly();
+        this.launchDarkly = {};
+    }
+
+    async initLaunchDarkly() {
+        this.launchDarkly = await new LaunchDarkly();
+        await this.launchDarkly.initialise();
     }
 
     async getBefore() {

--- a/test/end-to-end/paths/generic/cookieBanner.test.js
+++ b/test/end-to-end/paths/generic/cookieBanner.test.js
@@ -4,15 +4,7 @@ const TestConfigurator = new (require('test/end-to-end/helpers/TestConfigurator'
 
 Feature('Cookie Banner');
 
-// eslint complains that the Before/After are not used but they are by codeceptjs
-// so we have to tell eslint to not validate these
-// eslint-disable-next-line no-undef
-Before(async () => {
-    await TestConfigurator.getBefore();
-});
-
-// eslint-disable-next-line no-undef
-Scenario(TestConfigurator.idamInUseText('Check that the pages display a cookie banner with link'), async (I) => {
+Scenario('Check that the pages display a cookie banner with link', async (I) => {
 
     //Screeners & Pre-IDAM
     await I.clearCookie();

--- a/test/end-to-end/paths/generic/cookieBanner.test.js
+++ b/test/end-to-end/paths/generic/cookieBanner.test.js
@@ -12,11 +12,6 @@ Before(async () => {
 });
 
 // eslint-disable-next-line no-undef
-After(() => {
-    TestConfigurator.getAfter();
-});
-
-// eslint-disable-next-line no-undef
 Scenario(TestConfigurator.idamInUseText('Check that the pages display a cookie banner with link'), async (I) => {
 
     //Screeners & Pre-IDAM

--- a/test/end-to-end/paths/generic/survey.test.js
+++ b/test/end-to-end/paths/generic/survey.test.js
@@ -5,8 +5,7 @@ const optionYes = '';
 
 Feature('Survey');
 
-// eslint-disable-next-line no-undef
-Scenario(TestConfigurator.idamInUseText('Check survey link works'), async (I) => {
+Scenario('Check survey link works', async (I) => {
 
     // Eligibility Task (pre IdAM)
     await I.startApplication();

--- a/test/end-to-end/paths/intestacy/intestacy.en.test.js
+++ b/test/end-to-end/paths/intestacy/intestacy.en.test.js
@@ -32,6 +32,8 @@ After(() => {
 
 // eslint-disable-next-line no-undef
 Scenario(TestConfigurator.idamInUseText('GOP -Intestacy Journey - Digital iht'), async(I) => {
+    await I.retry(2).createAUser(TestConfigurator);
+
     const useNewDeathCertFlow = await TestConfigurator.checkFeatureToggle(config.featureToggles.ft_new_deathcert_flow);
 
     // Eligibility Task (pre IdAM)
@@ -137,6 +139,7 @@ Scenario(TestConfigurator.idamInUseText('GOP -Intestacy Journey - Digital iht'),
 
 // eslint-disable-next-line no-undef
 Scenario(TestConfigurator.idamInUseText('GOP -Intestacy Child Journey - Paper iht, no death certificate uploaded and spouse renouncing'), async (I) => {
+    await I.retry(2).createAUser(TestConfigurator);
 
     const useNewDeathCertFlow = await TestConfigurator.checkFeatureToggle(config.featureToggles.ft_new_deathcert_flow);
 

--- a/test/end-to-end/paths/intestacy/intestacy.en.test.js
+++ b/test/end-to-end/paths/intestacy/intestacy.en.test.js
@@ -21,6 +21,7 @@ Feature('Grant Of Probate Intestacy E2E Tests...');
 // so we have to tell eslint to not validate these
 // eslint-disable-next-line no-undef
 Before(async () => {
+    await TestConfigurator.initLaunchDarkly();
     await TestConfigurator.getBefore();
 });
 

--- a/test/end-to-end/paths/intestacy/intestacy.spouse.en.test.js
+++ b/test/end-to-end/paths/intestacy/intestacy.spouse.en.test.js
@@ -21,7 +21,14 @@ Before(async () => {
 });
 
 // eslint-disable-next-line no-undef
+After(() => {
+    TestConfigurator.getAfter();
+});
+
+// eslint-disable-next-line no-undef
 Scenario(TestConfigurator.idamInUseText('GOP -Intestacy Spouse Journey - Digital iht and death certificate uploaded'), async (I) => {
+    await I.retry(2).createAUser(TestConfigurator);
+
     // Eligibility Task (pre IdAM)
     await I.startApplication();
 

--- a/test/end-to-end/paths/intestacy/intestacy.spouse.en.test.js
+++ b/test/end-to-end/paths/intestacy/intestacy.spouse.en.test.js
@@ -21,11 +21,6 @@ Before(async () => {
 });
 
 // eslint-disable-next-line no-undef
-After(() => {
-    TestConfigurator.getAfter();
-});
-
-// eslint-disable-next-line no-undef
 Scenario(TestConfigurator.idamInUseText('GOP -Intestacy Spouse Journey - Digital iht and death certificate uploaded'), async (I) => {
     // Eligibility Task (pre IdAM)
     await I.startApplication();

--- a/test/end-to-end/paths/probate/gopSingleExecutor.en.test.js
+++ b/test/end-to-end/paths/probate/gopSingleExecutor.en.test.js
@@ -15,6 +15,7 @@ Feature('GOP-Single Executor flow...').retry(TestConfigurator.getRetryFeatures()
 // so we have to tell eslint to not validate these
 // eslint-disable-next-line no-undef
 Before(async () => {
+    await TestConfigurator.initLaunchDarkly();
     await TestConfigurator.getBefore();
 });
 

--- a/test/end-to-end/paths/probate/gopSingleExecutor.en.test.js
+++ b/test/end-to-end/paths/probate/gopSingleExecutor.en.test.js
@@ -25,6 +25,7 @@ After(() => {
 });
 
 Scenario(TestConfigurator.idamInUseText('Single Executor Journey with sign out/in and survey link'), async (I) => {
+    await I.retry(2).createAUser(TestConfigurator);
 
     const useNewDeathCertFlow = await TestConfigurator.checkFeatureToggle(config.featureToggles.ft_new_deathcert_flow);
 

--- a/test/end-to-end/paths/probate/multipleExecutors.js
+++ b/test/end-to-end/paths/probate/multipleExecutors.js
@@ -22,12 +22,19 @@ BeforeSuite(async () => {
     await TestConfigurator.getBefore();
 });
 
+// eslint-disable-next-line no-undef
+AfterSuite(() => {
+    TestConfigurator.getAfter();
+});
+
 Scenario(TestConfigurator.idamInUseText('Multiple Executors Journey - Main applicant; Stage 1: Enter deceased and executor details'), async (I) => {
     stage1retries += 1;
 
     if (stage1retries >= 1) {
         await TestConfigurator.getBefore();
     }
+
+    await I.retry(2).createAUser(TestConfigurator);
 
     // Eligibility Task (pre IdAM)
     await I.startApplication();

--- a/test/end-to-end/paths/probate/multipleExecutors.js
+++ b/test/end-to-end/paths/probate/multipleExecutors.js
@@ -147,11 +147,11 @@ Scenario(TestConfigurator.idamInUseText('Multiple Executors Journey - Main appli
         }
     }
 
-    // ************************************************
-    // Something is going wrong here
-    // in functional tests on CI after git push for pr.
-    // Works locally though using Puppeteer
-    // ************************************************
+    // Complete Equality & Diversity Questionnaire
+    if (TestConfigurator.equalityAndDiversityEnabled()) {
+        await I.exitEqualityAndDiversity();
+        await I.completeEqualityAndDiversity();
+    }
 
     // Review and Confirm Task
     await I.selectATask(taskListContent.taskNotStarted);

--- a/test/end-to-end/paths/probate/multipleExecutors.js
+++ b/test/end-to-end/paths/probate/multipleExecutors.js
@@ -10,30 +10,21 @@ const optionNo = '-2';
 const bilingualGOP = false;
 const uploadingDocuments = false;
 
-// let grabIds;
-let stage1retries = -1;
-
 Feature('Multiple Executors flow').retry(TestConfigurator.getRetryFeatures());
 
 // eslint complains that the Before/After are not used but they are by codeceptjs
 // so we have to tell eslint to not validate these
 // eslint-disable-next-line no-undef
-BeforeSuite(async () => {
+Before(async () => {
     await TestConfigurator.getBefore();
 });
 
 // eslint-disable-next-line no-undef
-AfterSuite(() => {
+After(() => {
     TestConfigurator.getAfter();
 });
 
 Scenario(TestConfigurator.idamInUseText('Multiple Executors Journey - Main applicant; Stage 1: Enter deceased and executor details'), async (I) => {
-    stage1retries += 1;
-
-    if (stage1retries >= 1) {
-        await TestConfigurator.getBefore();
-    }
-
     await I.retry(2).createAUser(TestConfigurator);
 
     // Eligibility Task (pre IdAM)
@@ -183,9 +174,11 @@ Scenario(TestConfigurator.idamInUseText('Multiple Executors Journey - Main appli
     for (let i=0; i < idList.ids.length; i++) {
 
         // eslint-disable-next-line no-await-in-loop
-        await I.amOnLoadedPage(testConfig.TestInvitationUrl + '/' + idList.ids[i]);
+        await I.amOnPage(testConfig.TestInvitationUrl + '/' + idList.ids[i]);
         // eslint-disable-next-line no-await-in-loop
-        await I.amOnLoadedPage(testConfig.TestE2EFrontendUrl + '/pin');
+        await I.amOnPage(testConfig.TestE2EFrontendUrl + '/pin');
+        // eslint-disable-next-line no-await-in-loop
+        await I.waitForElement('pre');
 
         const grabPins = await I.grabTextFrom('pre'); // eslint-disable-line no-await-in-loop
         const pinList = JSON.parse(grabPins);

--- a/test/end-to-end/paths/probate/multipleExecutors.js
+++ b/test/end-to-end/paths/probate/multipleExecutors.js
@@ -22,11 +22,6 @@ BeforeSuite(async () => {
     await TestConfigurator.getBefore();
 });
 
-// eslint-disable-next-line no-undef
-AfterSuite(() => {
-    TestConfigurator.getAfter();
-});
-
 Scenario(TestConfigurator.idamInUseText('Multiple Executors Journey - Main applicant; Stage 1: Enter deceased and executor details'), async (I) => {
     stage1retries += 1;
 

--- a/test/end-to-end/saucelabs.conf.js
+++ b/test/end-to-end/saucelabs.conf.js
@@ -61,6 +61,9 @@ const setupConfig = {
         },
         JSWait: {
             require: './helpers/JSWait.js'
+        },
+        IDAMHelper: {
+            require: './helpers/IDAMHelper.js'
         }
     },
     plugins: {

--- a/test/end-to-end/saucelabs.conf.js
+++ b/test/end-to-end/saucelabs.conf.js
@@ -3,8 +3,8 @@
 const supportedBrowsers = require('../crossbrowser/supportedBrowsers.js');
 const testConfig = require('config');
 
-const waitForTimeout = 60000;
-const smartWait = 10000;
+const waitForTimeout = parseInt(process.env.WAIT_FOR_TIMEOUT) || 30000;
+const smartWait = parseInt(process.env.SMART_WAIT) || 30000;
 const browser = process.env.SAUCELABS_BROWSER || 'chrome';
 const defaultSauceOptions = {
     username: process.env.SAUCE_USERNAME,
@@ -66,7 +66,7 @@ const setupConfig = {
     plugins: {
         retryFailedStep: {
             enabled: true,
-            retries: 2
+            retries: testConfig.TestRetrySteps
         },
         autoDelay: {
             enabled: true,


### PR DESCRIPTION
### JIRA link (if applicable) ###

Sub-task: https://tools.hmcts.net/jira/browse/DTSPB-1014
Parent Task: https://tools.hmcts.net/jira/browse/DTSPB-999

### Change description ###

This change includes the following to get the crossbrowser tests running successfully on Chrome:
- refactor LaunchDarkly initialisation in TestConfigurator.js, so that LaunchDarkly is only initialised and closed by tests that require it.
- refactor IDAM test user creation so that it can take advantage of Codecept's `.retry()` functionality
- delete IDAM test user during test teardown to help protect IDAM (apparently the source of some IDAM errors is due to the volume of stale test accounts)
- reduce number of retries so as not to waste time when a persistent failure is hit (this can cause Jenkins to timeout and so not test all browsers)
- ~~run only the working e2e tests (`multipleExecutors.js` is broken)~~  - fix for `multipleExecutors.js` test to be able to run Nightly
- fix JSWait.js for Edge browser
- handle Equality & Diversity Questionnaire on AAT in multipleExecutors.js functional test
- remove unnecessary setup and teardown steps from Cookie and Survey tests

**Does this PR introduce a breaking change?** (check one with "x")

```
[x] Yes (for e2e tests only)
[ ] No
```

Test Result of Chrome on Windows: [Success](https://build.platform.hmcts.net/view/PROBATE/job/HMCTS_Nightly_Probate/job/probate-frontend/view/change-requests/job/PR-1325/16/artifact/output/chrome_926e91f541aa50928c5536d7cd42ce53_1/mochawesome.html)

Test Result of Chrome on Mac: [Success](https://build.platform.hmcts.net/view/PROBATE/job/HMCTS_Nightly_Probate/job/probate-frontend/view/change-requests/job/PR-1325/16/artifact/output/chrome_6ef51182da55082aea942287faf69625_2/mochawesome.html)