### PR TITLE
DTSPB-2280 - Add specified "secureProtocol" to fix Fortify scan issue

### DIFF
--- a/app.js
+++ b/app.js
@@ -371,7 +371,8 @@ exports.init = function (isA11yTest = false, a11yTestSession = {}, ftValue) {
         const sslDirectory = path.join(__dirname, 'app', 'resources', 'localhost-ssl');
         const sslOptions = {
             key: fs.readFileSync(path.join(sslDirectory, 'localhost.key')),
-            cert: fs.readFileSync(path.join(sslDirectory, 'localhost.crt'))
+            cert: fs.readFileSync(path.join(sslDirectory, 'localhost.crt')),
+            secureProtocol: 'TLSv1_2_method'
         };
         const server = https.createServer(sslOptions, app);
 

--- a/test/java/build.gradle
+++ b/test/java/build.gradle
@@ -18,7 +18,8 @@ repositories {
 
 // tag::dependencies[]
 dependencies {
-    testCompile 'com.github.hmcts:fortify-client:1.2.0:all'
+    testCompile 'com.github.hmcts:fortify-client:1.2.0:all',
+    testCompile group: 'org.slf4j', name: 'slf4j-simple', version: '1.6.4'
 }
 // end::dependencies[]
 

--- a/test/java/build.gradle
+++ b/test/java/build.gradle
@@ -18,7 +18,7 @@ repositories {
 
 // tag::dependencies[]
 dependencies {
-    testCompile 'com.github.hmcts:fortify-client:1.2.0:all',
+    testCompile 'com.github.hmcts:fortify-client:1.2.0:all'
     testCompile group: 'org.slf4j', name: 'slf4j-simple', version: '1.6.4'
 }
 // end::dependencies[]


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSPB-2280

### Change description ###

- There is a critical issue for probate-frontend and probate-frontend-caveats where the explanation is given as:

The SSLv2, SSLv23, and SSLv3 protocols contain several flaws that make them insecure, so they should not be used to transmit sensitive data.

- This issue needs to be fixed so that Fortify scan step passes in the build.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
