### PR TITLE
fix for execNames field e2e from regex update

### DIFF
--- a/test/end-to-end/pages/executors/names.js
+++ b/test/end-to-end/pages/executors/names.js
@@ -12,7 +12,7 @@ module.exports = async function(language = 'en', totalExecutors = null) {
         // eslint-disable-next-line no-await-in-loop
         await I.waitForEnabled(locator);
         // eslint-disable-next-line no-await-in-loop
-        await I.fillField(locator, 'exec' + (i + 2));
+        await I.fillField(locator, 'exec' + String.fromCharCode('A'.charCodeAt(0) + i + 2));
         i += 1;
     }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###



### Change description ###
Updated e2e tests to make the executor names it uses use letters instead of numbers as numbers aren't allowed in the field i.e. exec2 to execB


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
