### PR TITLE
DTSPB-4378 Resolve text consistency issues when codicils are present

### DIFF
--- a/app/resources/cy/translation/applicant/nameasonwill.json
+++ b/app/resources/cy/translation/applicant/nameasonwill.json
@@ -3,6 +3,7 @@
   "reminder": "Gwiriwch yr ewyllys a’r codisiliau gwreiddiol nawr",
   "question": "A ydy {applicantName} yn union yr un fath â sut mae eich enw wedi ei ysgrifennu yn yr ewyllys?",
   "questionWithoutName": "A yw eich enw union beth sy&rsquo;n ymddangos ar yr ewyllys?",
+  "questionWithoutNameWithCodicil": "A yw eich enw union beth sy’n ymddangos ar yr ewyllys neu unrhyw godisiliau?",
   "questionWithCodicil": "Ai {applicantName} yw sut mae eich enw wedi ei ysgrifennu yn union yn yr ewyllys neu unrhyw godisiliau?",
   "content1": "Mae angen i ni wybod a yw eich enw wedi’i ysgrifennu’n wahanol yn yr ewyllys neu mewn unrhyw godisiliau.",
   "content2": "Fe allai hyn fod oherwydd:",

--- a/app/resources/en/translation/applicant/nameasonwill.json
+++ b/app/resources/en/translation/applicant/nameasonwill.json
@@ -3,6 +3,7 @@
   "reminder": "Check the original will and codicils now",
   "question": "Is {applicantName} exactly how your name is written in the will?",
   "questionWithoutName": "Is your name exactly what appears on the will?",
+  "questionWithoutNameWithCodicil": "Is your name exactly what appears on the will or any codicils?",
   "questionWithCodicil": "Is {applicantName} exactly how your name is written in the will or any codicils?",
   "content1": "We need to know if your name is written differently in the will or any codicils.",
   "content2": "This could be because:",

--- a/app/steps/ui/applicant/nameasonwill/index.js
+++ b/app/steps/ui/applicant/nameasonwill/index.js
@@ -17,9 +17,18 @@ class ApplicantNameAsOnWill extends ValidationStep {
         };
     }
 
+    generateContent(ctx = {}, formdata = {}, language = 'en') {
+        this.setCodicilFlagInCtx(ctx, formdata);
+        return super.generateContent(ctx, formdata, language);
+    }
+
     handleGet(ctx, formdata) {
-        ctx.codicilPresent = (new WillWrapper(formdata.will)).hasCodicils();
+        this.setCodicilFlagInCtx(ctx, formdata);
         return [ctx];
+    }
+
+    setCodicilFlagInCtx(ctx, formdata) {
+        ctx.codicilPresent = (new WillWrapper(formdata.will)).hasCodicils();
     }
 
     handlePost(ctx, errors) {

--- a/app/steps/ui/applicant/nameasonwill/index.js
+++ b/app/steps/ui/applicant/nameasonwill/index.js
@@ -17,14 +17,10 @@ class ApplicantNameAsOnWill extends ValidationStep {
         };
     }
 
-    generateContent(ctx = {}, formdata = {}, language = 'en') {
-        this.setCodicilFlagInCtx(ctx, formdata);
-        return super.generateContent(ctx, formdata, language);
-    }
-
-    handleGet(ctx, formdata) {
-        this.setCodicilFlagInCtx(ctx, formdata);
-        return [ctx];
+    getContextData(req) {
+        const ctx = super.getContextData(req);
+        this.setCodicilFlagInCtx(ctx, req.session.form);
+        return ctx;
     }
 
     setCodicilFlagInCtx(ctx, formdata) {

--- a/app/steps/ui/summary/includes/executors-applicant.njk
+++ b/app/steps/ui/summary/includes/executors-applicant.njk
@@ -16,10 +16,20 @@
     alreadyDeclared = fields.summary.alreadyDeclared.value
 )}}
 
-{% set applicantNameAsOnWillQuestion = content.ApplicantNameAsOnWill.questionWithoutName %}
+{# this seems like the worst possible way to have a boolean comparison #}
+{# we're passing a boolean into this from js and we end up with a string? i have no idea here #}
+{% if fields.summary.codicilPresent.value == 'true' %}
+  {% set applicantNameAsOnWillQuestion = content.ApplicantNameAsOnWill.questionWithoutNameWithCodicil %}
 
-{% if fields.applicant.firstName.value and fields.applicant.lastName.value %}
-    {% set applicantNameAsOnWillQuestion = content.ApplicantNameAsOnWill.question | replace("{applicantName}", fields.applicant.firstName.value + " " + fields.applicant.lastName.value) %}
+  {% if fields.applicant.firstName.value and fields.applicant.lastName.value %}
+      {% set applicantNameAsOnWillQuestion = content.ApplicantNameAsOnWill.questionWithCodicil | replace("{applicantName}", fields.applicant.firstName.value + " " + fields.applicant.lastName.value) %}
+  {% endif %}
+{% else %}
+  {% set applicantNameAsOnWillQuestion = content.ApplicantNameAsOnWill.questionWithoutName %}
+
+  {% if fields.applicant.firstName.value and fields.applicant.lastName.value %}
+      {% set applicantNameAsOnWillQuestion = content.ApplicantNameAsOnWill.question | replace("{applicantName}", fields.applicant.firstName.value + " " + fields.applicant.lastName.value) %}
+  {% endif %}
 {% endif %}
 
 {{checkanswer(

--- a/app/steps/ui/summary/index.js
+++ b/app/steps/ui/summary/index.js
@@ -109,6 +109,7 @@ class Summary extends Step {
             ctx.deceasedNameAsOnWillQuestion = content.DeceasedNameAsOnWill.question
                 .replace('{deceasedName}', deceasedName ? deceasedName : content.DeceasedNameAsOnWill.theDeceased);
             ctx.aliasNameOnWill = FormatName.formatAliasNameOnWIll(formdata.deceased);
+            ctx.codicilPresent = hasCodicils;
         } else {
             ctx.ihtThreshold = IhtThreshold.getIhtThreshold(new Date(get(formdata, 'deceased.dod-date')));
             ctx.deceasedMaritalStatusQuestion = content.DeceasedMaritalStatus.question

--- a/test/component/applicant/testNameAsOnWill.js
+++ b/test/component/applicant/testNameAsOnWill.js
@@ -33,7 +33,7 @@ describe('applicant-name-as-on-will', () => {
                     lastName: 'TheApplicant'
                 }
             };
-            const contentToExclude = ['questionWithoutName', 'questionWithCodicil', 'legendWithCodicil'];
+            const contentToExclude = ['questionWithoutName', 'questionWithCodicil', 'questionWithoutNameWithCodicil', 'legendWithCodicil'];
 
             testWrapper.agent.post('/prepare-session/form')
                 .send(sessionData)
@@ -61,7 +61,7 @@ describe('applicant-name-as-on-will', () => {
                     codicils: 'optionYes'
                 }
             };
-            const contentToExclude = ['question', 'questionWithoutName', 'legend'];
+            const contentToExclude = ['question', 'questionWithoutName', 'questionWithoutNameWithCodicil', 'legend'];
 
             testWrapper.agent.post('/prepare-session/form')
                 .send(sessionData)

--- a/test/component/applicant/testNameAsOnWill.js
+++ b/test/component/applicant/testNameAsOnWill.js
@@ -89,6 +89,56 @@ describe('applicant-name-as-on-will', () => {
                 });
         });
 
+        it('displays correct question displayed after error', (done) => {
+            const applFN = 'John';
+            const applLN = 'TheApplicant';
+            const applName = `${applFN} ${applLN}`;
+            const sessionData = {
+                applicant: {
+                    firstName: applFN,
+                    lastName: applLN,
+                },
+                will: {
+                    codicils: 'optionNo',
+                },
+            };
+
+            const qWithoutCodicil = testWrapper.content_en.question;
+            const formattedQuestionWithoutCodicil = qWithoutCodicil.replace('{applicantName}', applName);
+            testWrapper.agent.post('/prepare-session/form')
+                .send(sessionData)
+                .end(() => {
+                    testWrapper.testContentAfterError({}, [
+                        formattedQuestionWithoutCodicil
+                    ], done);
+                });
+        });
+
+        it('displays correct question displayed after error with codicil', (done) => {
+            const applFN = 'John';
+            const applLN = 'TheApplicant';
+            const applName = `${applFN} ${applLN}`;
+            const sessionData = {
+                applicant: {
+                    firstName: applFN,
+                    lastName: applLN,
+                },
+                will: {
+                    codicils: 'optionYes',
+                },
+            };
+
+            const qWithCodicil = testWrapper.content_en.questionWithCodicil;
+            const formattedQuestionWithCodicil = qWithCodicil.replace('{applicantName}', applName);
+            testWrapper.agent.post('/prepare-session/form')
+                .send(sessionData)
+                .end(() => {
+                    testWrapper.testContentAfterError({}, [
+                        formattedQuestionWithCodicil
+                    ], done);
+                });
+        });
+
         it(`test it redirects to next page when Yes selected: ${expectedNextUrlForApplicantPhone}`, (done) => {
             const sessionData = {
                 applicant: {

--- a/test/unit/applicant/testApplicantNameAsOnWill.js
+++ b/test/unit/applicant/testApplicantNameAsOnWill.js
@@ -14,6 +14,36 @@ describe('ApplicantNameAsOnWill', () => {
         });
     });
 
+    describe('handleGet()', () => {
+        it('should report codicilsPresent true if codicils in will', (done) => {
+            const ctxIn = {};
+            const formdataWithCodicils = {
+                will: {
+                    codicils: 'optionYes',
+                },
+            };
+
+            const [ctxWith,] = ApplicantNameAsOnWill.handleGet(ctxIn, formdataWithCodicils);
+
+            expect(ctxWith).to.have.property('codicilPresent', true);
+            done();
+        });
+
+        it('should report codicilsPresent false if no codicils in will', (done) => {
+            const ctxIn = {};
+            const formdataWithoutCodicils = {
+                will: {
+                    codicils: 'optionNo',
+                },
+            };
+
+            const [ctxWithout,] = ApplicantNameAsOnWill.handleGet(ctxIn, formdataWithoutCodicils);
+
+            expect(ctxWithout).to.have.property('codicilPresent', false);
+            done();
+        });
+    });
+
     describe('handlePost()', () => {
         let ctx;
         let errors;

--- a/test/unit/applicant/testApplicantNameAsOnWill.js
+++ b/test/unit/applicant/testApplicantNameAsOnWill.js
@@ -14,30 +14,36 @@ describe('ApplicantNameAsOnWill', () => {
         });
     });
 
-    describe('handleGet()', () => {
-        it('should report codicilsPresent true if codicils in will', (done) => {
-            const ctxIn = {};
-            const formdataWithCodicils = {
-                will: {
-                    codicils: 'optionYes',
+    describe('getContextData()', () => {
+        it('should report codicilsPresent True if codicils in will', (done) => {
+            const reqIn = {
+                session: {
+                    form: {
+                        will: {
+                            codicils: 'optionYes',
+                        }
+                    },
                 },
             };
 
-            const [ctxWith,] = ApplicantNameAsOnWill.handleGet(ctxIn, formdataWithCodicils);
+            const ctxWith = ApplicantNameAsOnWill.getContextData(reqIn);
 
             expect(ctxWith).to.have.property('codicilPresent', true);
             done();
         });
 
-        it('should report codicilsPresent false if no codicils in will', (done) => {
-            const ctxIn = {};
-            const formdataWithoutCodicils = {
-                will: {
-                    codicils: 'optionNo',
+        it('should report codicilsPresent False if no codicils in will', (done) => {
+            const reqIn = {
+                session: {
+                    form: {
+                        will: {
+                            codicils: 'optionNo',
+                        }
+                    },
                 },
             };
 
-            const [ctxWithout,] = ApplicantNameAsOnWill.handleGet(ctxIn, formdataWithoutCodicils);
+            const ctxWithout = ApplicantNameAsOnWill.getContextData(reqIn);
 
             expect(ctxWithout).to.have.property('codicilPresent', false);
             done();

--- a/test/unit/testSummary.js
+++ b/test/unit/testSummary.js
@@ -115,6 +115,7 @@ describe('Summary', () => {
                 ...coreContextMockData,
                 authToken: '1234',
                 alreadyDeclared: false,
+                codicilPresent: false,
                 deceasedAliasQuestion: 'Did Dee Ceased have assets in another name?',
                 diedEnglandOrWalesQuestion: 'Did Dee Ceased die in England or Wales?',
                 deceasedNameAsOnWillQuestion: 'Is Dee Ceased exactly how the name is written on the will?',

--- a/test/unit/testSummaryCodicils.js
+++ b/test/unit/testSummaryCodicils.js
@@ -1,0 +1,63 @@
+'use strict';
+
+const initSteps = require('app/core/initSteps');
+const {expect} = require('chai');
+
+describe('Summary - Codicils', () => {
+    const steps = initSteps([`${__dirname}/../../app/steps/action/`, `${__dirname}/../../app/steps/ui`]);
+    const baseReq = {
+        sessionID: 'dummy_sessionId',
+        session: {
+            language: 'en',
+            form: {
+                ccdCase: {
+                    id: 1234567890123456,
+                    state: 'Pending'
+                },
+                caseType: 'gop',
+                deceased: {
+                    firstName: 'Dee',
+                    lastName: 'Ceased',
+                    'dod-date': '2022-02-02',
+                    'dod-formattedDate': '2 February 2022',
+                    aliasFirstNameOnWill: 'firstNameOnWill',
+                    aliasLastNameOnWill: 'lastNameOnWill'
+                },
+                iht: {
+                    netValue: 300000
+                },
+                will: {},
+            }
+        },
+        authToken: '1234'
+    };
+
+    describe('getContextData()', () => {
+        it('[PROBATE] return the correct properties in ctx when codicils not present', (done) => {
+            const req = baseReq;
+            req.session.form.will.codicils = 'optionNo';
+
+            const Summary = steps.Summary;
+            const ctx = Summary.getContextData(req);
+
+            expect(ctx).to.have.property('codicilPresent', false);
+            expect(ctx).to.have.property(
+                'deceasedMarriedQuestion',
+                'Did Dee Ceased get married or enter into a civil partnership after the will was signed?');
+            done();
+        });
+
+        it('[PROBATE] return the correct properties in ctx when codicils present', (done) => {
+            const req = baseReq;
+            req.session.form.will.codicils = 'optionYes';
+
+            const Summary = steps.Summary;
+            const ctx = Summary.getContextData(req);
+            expect(ctx).to.have.property('codicilPresent', true);
+            expect(ctx).to.have.property(
+                'deceasedMarriedQuestion',
+                'Did Dee Ceased get married or enter into a civil partnership after the latest codicil was signed?');
+            done();
+        });
+    });
+});


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPB-4378

### Change description ###
Adds handling to ensure that the alternate form of messaging is used even after there's an error on submission of the nameAsOnWill, as well as tests to validate the behaviour on the summary page (as well as for the marriage question).

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
