### PR TITLE
enable corepack, update yarn calls to work in v4.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,11 +8,12 @@ USER hmcts
 ENV WORKDIR /opt/app
 WORKDIR ${WORKDIR}
 
-
 COPY --chown=hmcts:hmcts package.json yarn.lock ./
-RUN yarn config set http-proxy "$http_proxy" && yarn config set https-proxy "$https_proxy"
-RUN yarn install --production  \
-    && yarn cache clean
+
+RUN yarn config set httpProxy "$http_proxy" \
+    && yarn config set httpsProxy "$https_proxy" \
+    && yarn workspaces focus --all --production \
+    && rm -rf $(yarn cache clean)
 # ---- Build image ----
 FROM base as build
 COPY --chown=hmcts:hmcts . ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # ---- Base image ----
 
 FROM hmctspublic.azurecr.io/base/node:20-alpine as base
-#USER root
-#RUN corepack enable
-#USER hmcts
+USER root
+RUN corepack enable
+USER hmcts
 
 ENV WORKDIR /opt/app
 WORKDIR ${WORKDIR}


### PR DESCRIPTION
### Change description ###
it seems that the build issues we've been seeing are due to our dockerized builds using yarn v1.22.22

with some change overnight monday to tuesday this started to cause issues as the build checked the corepack configuration which declares the project should be built with v4.6.0 and thus fails.

this change:
- enables corepack (which was never enabled but is present commented out)
- fixes the yarn commands to run correctly under 4.6.0

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
