### PR TITLE
DTSPB-4626 Make status comparison case insensitive for payments.

### DIFF
--- a/app/services/Payment.js
+++ b/app/services/Payment.js
@@ -50,11 +50,11 @@ class Payment extends Service {
     identifySuccessfulOrInitiatedPayment(casePayments) {
         let response = false;
         forEach(casePayments.payments, (payment) => {
-            if (payment.status === 'Success') {
+            if (payment.status.toLowerCase() === 'success') {
                 this.log(`Found a successful payment: ${payment.payment_reference}`);
                 response = payment;
                 return false;
-            } else if (payment.status === 'Initiated') {
+            } else if (payment.status.toLowerCase() === 'initiated') {
                 this.log(`Found an initiated payment: ${payment.payment_reference}`);
                 response = payment;
             }

--- a/app/steps/ui/payment/breakdown/index.js
+++ b/app/steps/ui/payment/breakdown/index.js
@@ -92,7 +92,7 @@ class PaymentBreakdown extends Step {
 
             const [canCreatePayment, paymentStatus] = yield this.canCreatePayment(ctx, formdata, serviceAuthResult);
             logger.info(`canCreatePayment result = ${canCreatePayment} with status ${paymentStatus}`);
-            if (paymentStatus === 'Initiated') {
+            if (paymentStatus && paymentStatus.toLowerCase() === 'initiated') {
                 const paymentCreateServiceUrl = config.services.payment.url + config.services.payment.paths.createPayment;
                 const payment = new Payment(paymentCreateServiceUrl, ctx.sessionID);
                 const data = {
@@ -103,7 +103,7 @@ class PaymentBreakdown extends Step {
                 };
                 const paymentResponse = yield payment.get(data);
                 logger.info('Checking status of reference = ' + ctx.reference + ' with response = ' + paymentResponse.status);
-                if (paymentResponse.status === 'Initiated') {
+                if (paymentResponse.status && paymentResponse.status.toLowerCase() === 'initiated') {
                     logger.error('As payment is still Initiated, user will need to wait for this state to expire.');
                     errors.push(FieldError('payment', 'initiated', this.resourcePath, this.generateContent(ctx, formdata, session.language), session.language));
                     return [ctx, errors];
@@ -217,7 +217,9 @@ class PaymentBreakdown extends Step {
             logger.debug(`Payment retrieval in breakdown for caseId = ${caseId} with response = ${JSON.stringify(paymentResponse)}`);
             if (!paymentResponse) {
                 logger.info('No payments of Initiated or Success found for case.');
-            } else if (paymentResponse.status === 'Initiated' || paymentResponse.status === 'Success') {
+            } else if (paymentResponse.status &&
+                    (paymentResponse.status.toLowerCase() === 'initiated' ||
+                        paymentResponse.status.toLowerCase() === 'success')) {
                 paymentStatus = paymentResponse.status;
                 if (paymentResponse.payment_reference !== paymentReference) {
                     logger.info(`Payment with status ${paymentResponse.status} found, using reference ${paymentResponse.payment_reference}.`);


### PR DESCRIPTION
### JIRA link (if applicable) ###
See [DTSPB-4626](https://tools.hmcts.net/jira/browse/DTSPB-4626)

### Change description ###
Make payment status comparison case-insensitive. Currently nothing prevents repeated payments if requested multiple times because this checks for Capital versions and the payments api returns lowercase. Should probably actually make the interface a little better verified in the longer term but lets do what we can to stop multiple payments.

Note there is still a possible race condition if multiple sessions/tabs are open and request within the window between the first request asking for the current payment statuses and it starting a new payment.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
