### PR TITLE
DTSPB-4916 Workaround to submit cases with no payment needed.

### DIFF
--- a/app/steps/ui/payment/breakdown/index.js
+++ b/app/steps/ui/payment/breakdown/index.js
@@ -173,6 +173,7 @@ class PaymentBreakdown extends Step {
                     const formDataResult = yield this.submitForm(ctx, errors, formdata, notReqPayment, serviceAuthResult, session.language);
                     set(formdata, 'ccdCase', formDataResult.ccdCase);
                     set(formdata, 'payment', formDataResult.payment);
+                    delete this.nextStepUrl;
                 }
             } else {
                 delete this.nextStepUrl;

--- a/charts/probate-frontend/values.preview.template.yaml
+++ b/charts/probate-frontend/values.preview.template.yaml
@@ -1,6 +1,10 @@
 nodejs:
   image: ${IMAGE_NAME}
   ingressHost: ${SERVICE_NAME}.preview.platform.hmcts.net
+  memoryRequests: 64Mi
+  memoryLimits: 1Gi
+  devmemoryRequests: 64Mi
+  devmemoryLimits: 1Gi
   autoscaling:
     enabled: false
   environment:

--- a/test/unit/payment/testPaymentBreakdown.js
+++ b/test/unit/payment/testPaymentBreakdown.js
@@ -257,7 +257,18 @@ describe('PaymentBreakdown', () => {
             co(function* () {
                 [ctx, errors] = yield paymentBreakdown.handlePost(ctx, errors, formdata, session, hostname);
                 expect(paymentBreakdown.nextStepUrl(req)).to.equal('/payment-status');
-                expect(errors).to.deep.equal(errorsTestData);
+                // DTSPB-4916 this is a mess... the current tests where a call to submit the case are all
+                // playing a little loose with the actual behaviour being tested as they seem to pass the
+                // errorsTestData reference into the handlePost call which then mutates it.
+                // This means that when they then check errors === errorsTestData this is true, but the content of
+                // errorsTestData is no longer the same as at the start of the test.
+                // The error itself is because the SubmitData service is not being mocked, so it is attempting to
+                // reach a URL which cannot be accessed which fails.
+                expect(errors).to.deep.equal([{
+                    field: 'submit',
+                    href: '#submit',
+                    msg: content.errors.submit.failure
+                }]);
                 done();
             }).catch((err) => {
                 done(err);

--- a/test/unit/payment/testPaymentBreakdown.js
+++ b/test/unit/payment/testPaymentBreakdown.js
@@ -225,6 +225,9 @@ describe('PaymentBreakdown', () => {
             let ctx = {total: 0};
             let errors = [];
             const formdata = {
+                ccdCase: {
+                    id: 1,
+                },
                 fees: {
                     total: 0,
                     ukcopiesfee: 0,


### PR DESCRIPTION
### JIRA link (if applicable) ###

See [DTSPB-4916](https://tools.hmcts.net/jira/browse/DTSPB-4916)


### Change description ###
this causes a later failure (since this updates the case data out of cycle) and ends up redirecting the user back to the dashboard rather than to the thank-you page which means they are not shown directly what information they need to send via post (though they should receive an email with this information and it can be accessed via the 'View application progress' link from the dashboard.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
