### PR TITLE
Dtspb 4957 prevent memory leak when pages are loaded

### DIFF
--- a/app.js
+++ b/app.js
@@ -415,5 +415,30 @@ exports.init = function (isA11yTest = false, a11yTestSession = {}, ftValue) {
         });
     });
 
+    if (process.env.NODE_ENV === 'dev-aat' || process.env.NODE_ENV === 'dev-pr') {
+        const v8 = require('node:v8');
+
+        const inMb = (v) => (v / 1024 / 1024).toFixed(2);
+        const doLogMem = () => {
+            const heapStat = v8.getHeapStatistics();
+
+            const logMsg = 'Current memory usage (in mb): ' +
+                `totalHeapSize=${inMb(heapStat.total_heap_size)} ` +
+                `totalHeapSizeExec=${inMb(heapStat.total_heap_size_executable)} ` +
+                `totalPhysicalSize=${inMb(heapStat.total_physical_size)} ` +
+                `totalAvailableSize=${inMb(heapStat.total_available_size)} ` +
+                `usedHeapSize=${inMb(heapStat.used_heap_size)} ` +
+                `heapSizeLimit=${inMb(heapStat.heap_size_limit)}`;
+
+            logger('MemUsage').info(logMsg);
+        };
+
+        logger('MemUsage').info('Scheduling memory reporting every 60 seconds');
+        const logMem = setInterval(doLogMem, 60000);
+    } else {
+        logger('MemUsage')
+            .info('Not triggering regular memory logging for production-like environment');
+    }
+
     return {app, http};
 };

--- a/app.js
+++ b/app.js
@@ -415,7 +415,9 @@ exports.init = function (isA11yTest = false, a11yTestSession = {}, ftValue) {
         });
     });
 
-    if (process.env.NODE_ENV === 'dev-aat' || process.env.NODE_ENV === 'dev-pr') {
+    const environment = config.environment;
+    const memlogEnvironments = ['aat'];
+    if (memlogEnvironments.includes(environment)) {
         const v8 = require('node:v8');
 
         const inMb = (v) => (v / 1024 / 1024).toFixed(2);
@@ -433,11 +435,12 @@ exports.init = function (isA11yTest = false, a11yTestSession = {}, ftValue) {
             logger('MemUsage').info(logMsg);
         };
 
-        logger('MemUsage').info('Scheduling memory reporting every 60 seconds');
+        logger('MemUsage')
+            .info(`Scheduling memory reporting every 60 seconds in config.environment: ${environment}`);
         const logMem = setInterval(doLogMem, 60000);
     } else {
         logger('MemUsage')
-            .info('Not triggering regular memory logging for production-like environment');
+            .info(`Not triggering regular memory logging for config.environment: ${environment}`);
     }
 
     return {app, http};

--- a/app/routes.js
+++ b/app/routes.js
@@ -146,22 +146,6 @@ router.use(['/task-list', '/assets-overseas', '/copies-overseas', '/copies-uk', 
     }
 });
 
-const allSteps = {
-    'en': initSteps([`${__dirname}/steps/action/`, `${__dirname}/steps/ui`], 'en'),
-    'cy': initSteps([`${__dirname}/steps/action/`, `${__dirname}/steps/ui`], 'cy')
-};
-const allPageUrls = [];
-Object.entries(allSteps.en).forEach(([, step]) => {
-    const stepUrl = step.constructor.getUrl();
-    const cleanStepUrl = FormatUrl.getCleanPageUrl(stepUrl, 1);
-    if (!allPageUrls.includes(cleanStepUrl)) {
-        allPageUrls.push(cleanStepUrl);
-    }
-
-    router.get(stepUrl, step.runner().GET(step));
-    router.post(stepUrl, step.runner().POST(step));
-});
-
 router.use((req, res, next) => {
     const currentPageCleanUrl = FormatUrl.getCleanPageUrl(req.originalUrl, 1);
     const formdata = req.session.form;
@@ -252,5 +236,21 @@ const redirectTaskList = (req, currentPageCleanUrl, formdata, applicationSubmitt
         return true;
     }
 };
+
+const allSteps = {
+    'en': initSteps([`${__dirname}/steps/action/`, `${__dirname}/steps/ui`], 'en'),
+    'cy': initSteps([`${__dirname}/steps/action/`, `${__dirname}/steps/ui`], 'cy')
+};
+const allPageUrls = [];
+Object.entries(allSteps.en).forEach(([, step]) => {
+    const stepUrl = step.constructor.getUrl();
+    const cleanStepUrl = FormatUrl.getCleanPageUrl(stepUrl, 1);
+    if (!allPageUrls.includes(cleanStepUrl)) {
+        allPageUrls.push(cleanStepUrl);
+    }
+
+    router.get(stepUrl, step.runner().GET(step));
+    router.post(stepUrl, step.runner().POST(step));
+});
 
 module.exports = router;

--- a/app/routes.js
+++ b/app/routes.js
@@ -150,9 +150,19 @@ const allSteps = {
     'en': initSteps([`${__dirname}/steps/action/`, `${__dirname}/steps/ui`], 'en'),
     'cy': initSteps([`${__dirname}/steps/action/`, `${__dirname}/steps/ui`], 'cy')
 };
+const allPageUrls = [];
+Object.entries(allSteps.en).forEach(([, step]) => {
+    const stepUrl = step.constructor.getUrl();
+    const cleanStepUrl = FormatUrl.getCleanPageUrl(stepUrl, 1);
+    if (!allPageUrls.includes(cleanStepUrl)) {
+        allPageUrls.push(cleanStepUrl);
+    }
+
+    router.get(stepUrl, step.runner().GET(step));
+    router.post(stepUrl, step.runner().POST(step));
+});
 
 router.use((req, res, next) => {
-    const steps = allSteps[req.session.language];
     const currentPageCleanUrl = FormatUrl.getCleanPageUrl(req.originalUrl, 1);
     const formdata = req.session.form;
 
@@ -166,17 +176,6 @@ router.use((req, res, next) => {
     const date = (formdata.reviewresponse?.expectedResponseDate || formdata.expectedResponseDate)? utils.formattedDate(moment(formdata.reviewresponse?.expectedResponseDate || formdata.expectedResponseDate, 'YYYY-MM-DD').parseZone(), req.session.language): null;
     const informationProvided = CaseProgress.informationProvided(formdata.ccdCase?.state, formdata.provideinformation?.documentUploadIssue, date);
     const partialInformationProvided = CaseProgress.partialInformationProvided(formdata.ccdCase?.state, formdata.provideinformation?.documentUploadIssue, date, formdata.provideinformation?.citizenResponse, formdata.documents?.uploads.map(doc => doc.filename), formdata.provideinformation?.isSaveAndClose);
-
-    const allPageUrls = [];
-    Object.entries(steps).forEach(([, step]) => {
-        const stepUrl = FormatUrl.getCleanPageUrl(step.constructor.getUrl(), 1);
-        if (!allPageUrls.includes(stepUrl)) {
-            allPageUrls.push(stepUrl);
-        }
-
-        router.get(step.constructor.getUrl(), step.runner().GET(step));
-        router.post(step.constructor.getUrl(), step.runner().POST(step));
-    });
 
     const noCcdCaseIdPages = config.noCcdCaseIdPages.map(item => FormatUrl.getCleanPageUrl(item, 0));
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
See [DTSPB-4957](https://tools.hmcts.net/jira/browse/DTSPB-4957)


### Change description ###
Moves the initial routing handling for pages to be outside of a routing callback. This may have impacts on english/welsh text handling but initial bench testing suggests this is working as expected still.

This also adds a periodic (once per minute) log message with current memory usage. This might help in future to identify cases where the memory usage is ballooning in the way we saw before this change to the routing handling.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
