### PR TITLE
DTSPB-4918 correctly render back link in welsh

### DIFF
--- a/app/views/includes/layout.html
+++ b/app/views/includes/layout.html
@@ -112,7 +112,7 @@ html: (common.feedback + common.languageToggle) | replace("{smartSurveyFeedbackU
 
 
     {% if showBackLink %}
-    <span class="govuk-back-link govuk-visually-hidden" id="backLink">{{common.back }}</span>
+    <span class="govuk-back-link govuk-visually-hidden" id="backLink">{{common.back | safe}}</span>
     {% endif %}
 
 {% endblock %}


### PR DESCRIPTION
### JIRA link (if applicable) ###
See [DTSPB-4918](https://tools.hmcts.net/jira/browse/DTSPB-4918)

### Change description ###
Returns the `safe` filter to the back link as otherwise the welsh text renders as `Yn &ocirc;l` rather than `Yn ôl`


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
